### PR TITLE
Add DASH role scheme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,9 @@ Optional fields:
 * `label` - a friendly string that identifies the sequence. If a language is specified,
 	a default label will be automatically derived by it - e.g. if language is `ita`, 
 	by default `italiano` will be used as the label.
+* `roles` - an array of DASH role schemes as defined in ISO/IEC 23009-1 Section 5.8.5.5. For roles
+	such as `caption` or `description`, the label must be explicitly specified. The default label
+	does not take roles into account.
 * `default` - a boolean that sets the value of the DEFAULT attribute of EXT-X-MEDIA tags using this sequence.
 	If not specified, the first EXT-X-MEDIA tag in each group returns DEFAULT=YES, while the others return DEFAULT=NO.
 * `bitrate` - an object that can be used to set the bitrate for the different media types,

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -1082,6 +1082,15 @@ ngx_http_vod_parse_uri_path(
 		cur_sequence->tags.language = 0;
 		cur_sequence->tags.label.len = 0;
 		cur_sequence->tags.is_default = -1;
+
+		rc = ngx_array_init(&cur_sequence->tags.roles, r->pool, 1, sizeof(ngx_str_t));
+		if (rc != NGX_OK)
+		{
+			ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+				"ngx_http_vod_parse_uri_path: roles ngx_array_init failed");
+			return ngx_http_vod_status_to_ngx_error(r, VOD_ALLOC_FAILED);
+		}
+
 		cur_sequence->first_key_frame_offset = 0;
 		cur_sequence->key_frame_durations = NULL;
 		cur_sequence->drm_info = NULL;

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -64,6 +64,9 @@
 	"        maxHeight=\"%uD\"\n"												\
 	"        maxFrameRate=\"%V\">\n"
 
+#define VOD_DASH_MANIFEST_ADAPTATION_ROLE										\
+	"      <Role schemeIdUri=\"urn:mpeg:dash:role:2011\" value=\"%V\"/>\n"
+
 #define VOD_DASH_MANIFEST_REPRESENTATION_HEADER_VIDEO							\
 	"      <Representation\n"													\
 	"          id=\"%V\"\n"														\
@@ -127,20 +130,21 @@
 #define VOD_DASH_MANIFEST_REPRESENTATION_FOOTER									\
 	"      </Representation>\n"
 
-#define VOD_DASH_MANIFEST_ADAPTATION_FOOTER										\
-	"    </AdaptationSet>\n"
-
-#define VOD_DASH_MANIFEST_ADAPTATION_SUBTITLE_VTT								\
+#define VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT						\
 	"    <AdaptationSet\n"														\
 	"        contentType=\"text\"\n"											\
 	"        lang=\"%V\"\n"														\
 	"        label=\"%V\"\n"													\
-	"        mimeType=\"text/vtt\">\n"											\
+	"        mimeType=\"text/vtt\">\n"
+
+#define VOD_DASH_MANIFEST_REPRESENTATION_SUBTITLE_VTT					\
 	"      <Representation\n"													\
 	"          id=\"textstream_%s_%uD\"\n"										\
 	"          bandwidth=\"0\">\n"												\
 	"        <BaseURL>%V%V-%s%V.vtt</BaseURL>\n"								\
-	"      </Representation>\n"													\
+	"      </Representation>\n"
+
+#define VOD_DASH_MANIFEST_ADAPTATION_FOOTER										\
 	"    </AdaptationSet>\n"
 
 
@@ -200,6 +204,7 @@
 #define MAX_INDEX_SHIFT_LENGTH (sizeof("i-") + VOD_INT32_LEN)
 #define MAX_MIME_TYPE_SIZE (sizeof("video/webm") - 1)
 #define MAX_FILE_EXT_SIZE (sizeof("webm") - 1)
+#define MAX_ROLE_SIZE (32)
 
 //typedefs
 typedef struct {
@@ -671,6 +676,20 @@ dash_packager_write_frame_rate(
 	}
 }
 
+static u_char*
+dash_packager_write_roles(u_char* p, media_info_t* media_info)
+{
+	vod_str_t* role = media_info->tags.roles.elts;
+	vod_str_t* last_role = role + media_info->tags.roles.nelts;
+
+	for (; role < last_role; role++)
+	{
+		p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_ROLE, role);
+	}
+
+	return p;
+}
+
 static uint32_t
 dash_packager_get_eac3_channel_config(media_info_t* media_info)
 {
@@ -919,16 +938,23 @@ dash_packager_write_mpd_period(
 				representation_id.len--;
 			}
 
-			lang_code = lang_get_rfc_5646_name(cur_track->media_info.tags.language);
-			p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_SUBTITLE_VTT,
+			p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT,
 				&cur_track->media_info.tags.lang_str,
-				&cur_track->media_info.tags.label,
+				&cur_track->media_info.tags.label);
+
+			p = dash_packager_write_roles(p, &cur_track->media_info);
+
+			lang_code = lang_get_rfc_5646_name(cur_track->media_info.tags.language);
+			p = vod_sprintf(p, VOD_DASH_MANIFEST_REPRESENTATION_SUBTITLE_VTT,
 				lang_code,
 				subtitle_adapt_id++, 
 				&cur_base_url,
 				&context->conf->subtitle_file_name_prefix,
 				clip_spec,
 				&representation_id);
+
+			p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_FOOTER);
+
 			continue;
 		}
 
@@ -939,6 +965,8 @@ dash_packager_write_mpd_period(
 				p,
 				reference_track);
 		}
+
+		p = dash_packager_write_roles(p, &reference_track->media_info);
 
 		// get the segment index start number
 		start_number = (*cur_duration_items)[0].segment_index;
@@ -1377,12 +1405,14 @@ dash_packager_build_mpd(
 		sizeof(VOD_DASH_MANIFEST_PERIOD_HEADER_START_DURATION) - 1 + 5 * VOD_INT32_LEN +
 			// video adaptations
 			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_VIDEO) - 1 + 3 * VOD_INT32_LEN + VOD_DASH_MAX_FRAME_RATE_LEN +
+			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_ROLE) - 1 + MAX_ROLE_SIZE) * 3 +
 			sizeof(VOD_DASH_MANIFEST_ADAPTATION_FOOTER) - 1) * context.adaptation_sets.count[ADAPTATION_TYPE_VIDEO] +
 			// video representations
 			(sizeof(VOD_DASH_MANIFEST_REPRESENTATION_HEADER_VIDEO) - 1 + MAX_TRACK_SPEC_LENGTH + MAX_MIME_TYPE_SIZE + MAX_CODEC_NAME_SIZE + 3 * VOD_INT32_LEN + VOD_DASH_MAX_FRAME_RATE_LEN +
 			sizeof(VOD_DASH_MANIFEST_REPRESENTATION_FOOTER) - 1) * media_set->track_count[MEDIA_TYPE_VIDEO] +
 			// audio adaptations
 			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO_LANG) - 1 + sizeof(VOD_DASH_MANIFEST_AUDIO_CHANNEL_CONFIG_EAC3) - 1 + 2 * VOD_INT32_LEN +
+			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_ROLE) - 1 + MAX_ROLE_SIZE) * 3 +
 			sizeof(VOD_DASH_MANIFEST_ADAPTATION_FOOTER) - 1) * context.adaptation_sets.count[ADAPTATION_TYPE_AUDIO] +
 			// audio representations
 			(sizeof(VOD_DASH_MANIFEST_REPRESENTATION_HEADER_AUDIO) - 1 + MAX_TRACK_SPEC_LENGTH + MAX_MIME_TYPE_SIZE + MAX_CODEC_NAME_SIZE + 2 * VOD_INT32_LEN +
@@ -1396,8 +1426,12 @@ dash_packager_build_mpd(
 	case SUBTITLE_FORMAT_WEBVTT:
 		base_period_size +=
 			// subtitle adaptations
-			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_SUBTITLE_VTT) - 1 + LANG_ISO639_3_LEN + VOD_INT32_LEN +
-			context.base_url.len + conf->subtitle_file_name_prefix.len + MAX_CLIP_SPEC_LENGTH + MAX_TRACK_SPEC_LENGTH) *
+			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT) - 1 + LANG_ISO639_3_LEN + VOD_INT32_LEN +
+			// subtitle roles
+			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_ROLE) - 1 + MAX_ROLE_SIZE) * 3 +
+			// subtitle representation
+			sizeof(VOD_DASH_MANIFEST_REPRESENTATION_SUBTITLE_VTT) - 1 + context.base_url.len + conf->subtitle_file_name_prefix.len + MAX_CLIP_SPEC_LENGTH + MAX_TRACK_SPEC_LENGTH +
+			sizeof(VOD_DASH_MANIFEST_ADAPTATION_FOOTER) - 1) *
 			context.adaptation_sets.count[ADAPTATION_TYPE_SUBTITLE];
 		break;
 

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -230,6 +230,7 @@ typedef struct {
 	vod_str_t lang_str;
 	vod_str_t label;
 	bool_t is_default;
+	vod_array_t roles;
 } media_tags_t;
 
 typedef struct media_info_s {


### PR DESCRIPTION
Support DASH role schemes as defined in ISO/IEC 23009-1 Section 5.8.5.5 per sequence.

#### Sample mapping

```json
{
  "sequences": [
    {
      "clips": [
        {
          "type": "source",
          "path": "tears-of-steel-avc1-1500k.mp4"
        }
      ],
      "roles": ["main"]  
    },
    {
      "clips": [
        {
          "type": "source",
          "path": "tears-of-steel-aac-128k.mp4"
        }
      ],
      "language": "eng",
      "label": "English",
      "roles": ["main"]
    },
    {
      "clips": [
        {
          "type": "source",
          "path": "tears-of-steel-en.srt"
        }
      ],
      "language": "eng",
      "label": "English",
      "roles": ["subtitle"]
    },
    {
      "clips": [
        {
          "type": "source",
          "path": "tears-of-steel-en-hoh.srt"
        }
      ],
      "language": "eng",
      "label": "English (CC)",
      "roles": ["subtitle", "caption"]
    }
  ]
}
```

#### Known limitations

- For roles such as `caption` or `description`, the label must be explicitly specified. The default label does not take roles into account.
- In adaptation sets containing multiple representations, only the roles from the last representation are used.