### PR TITLE
Add HLS characteristics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,11 @@ Optional fields:
 	by default `italiano` will be used as the label.
 * `default` - a boolean that sets the value of the DEFAULT attribute of EXT-X-MEDIA tags using this sequence.
 	If not specified, the first EXT-X-MEDIA tag in each group returns DEFAULT=YES, while the others return DEFAULT=NO.
+* `autoselect` - a boolean that sets the value of the AUTOSELECT attribute of EXT-X-MEDIA tags using this sequence.
+* `characteristics` - a string of HLS characteristics as defined in [RFC 8216 Section 4.3.4.1](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.1).
+	For characteristics such as `public.easy-to-read` or `public.accessibility.*`, the label must be explicitly
+	specified. The default label does not take characteristics into account.
+* `forced` - a boolean that sets the value of the FORCED attribute of EXT-X-MEDIA tags using this sequence.
 * `bitrate` - an object that can be used to set the bitrate for the different media types,
 	in bits per second. For example, `{"v": 900000, "a": 64000}`. If the bitrate is not supplied,
 	nginx-vod-module will estimate it based on the last clip in the sequence.

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -1081,6 +1081,9 @@ ngx_http_vod_parse_uri_path(
 		cur_sequence->tags.lang_str.len = 0;
 		cur_sequence->tags.language = 0;
 		cur_sequence->tags.label.len = 0;
+		cur_sequence->tags.is_forced = 0;
+		cur_sequence->tags.characteristics.len = 0;
+		cur_sequence->tags.is_autoselect = 0;
 		cur_sequence->tags.is_default = -1;
 		cur_sequence->first_key_frame_offset = 0;
 		cur_sequence->key_frame_durations = NULL;

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -229,6 +229,9 @@ typedef struct {
 	language_id_t language;
 	vod_str_t lang_str;
 	vod_str_t label;
+	bool_t is_forced;
+	vod_str_t characteristics;
+	bool_t is_autoselect;
 	bool_t is_default;
 } media_tags_t;
 

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -138,6 +138,9 @@ static json_object_value_def_t media_sequence_params[] = {
 	{ vod_string("language"),		VOD_JSON_STRING,	offsetof(media_sequence_t, tags.lang_str), media_set_parse_null_term_string },
 	{ vod_string("label"),			VOD_JSON_STRING,	offsetof(media_sequence_t, tags.label), media_set_parse_null_term_string },
 	{ vod_string("default"),		VOD_JSON_BOOL,		offsetof(media_sequence_t, tags.is_default), media_set_parse_bool },
+	{ vod_string("autoselect"),		VOD_JSON_BOOL,		offsetof(media_sequence_t, tags.is_autoselect), media_set_parse_bool },
+	{ vod_string("characteristics"),VOD_JSON_STRING,	offsetof(media_sequence_t, tags.characteristics), media_set_parse_null_term_string },
+	{ vod_string("forced"),			VOD_JSON_BOOL,		offsetof(media_sequence_t, tags.is_forced), media_set_parse_bool },
 	{ vod_string("bitrate"),		VOD_JSON_OBJECT,	offsetof(media_sequence_t, bitrate), media_set_parse_bitrate },
 	{ vod_string("avg_bitrate"),	VOD_JSON_OBJECT,	offsetof(media_sequence_t, avg_bitrate), media_set_parse_bitrate },
 	{ vod_null_string, 0, 0, NULL }
@@ -978,6 +981,9 @@ media_set_parse_sequences(
 		cur_output->tags.lang_str.len = 0;
 		cur_output->tags.language = 0;
 		cur_output->tags.label.len = 0;
+		cur_output->tags.is_forced = 0;
+		cur_output->tags.characteristics.len = 0;
+		cur_output->tags.is_autoselect = 0;
 		cur_output->tags.is_default = -1;
 		cur_output->first_key_frame_offset = 0;
 		cur_output->key_frame_durations = NULL;


### PR DESCRIPTION
Support HLS characteristics as defined in [RFC 8216 Section 4.3.4.1](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.1) per sequence. Additionally, support FORCED subtitles and make AUTOSELECT adjustable.

#### Sample mapping

```json
{
  "sequences": [
    {
      "clips": [
        {
          "type": "source",
          "path": "tears-of-steel-avc1-1500k.mp4"
        }
      ]
    },
    {
      "clips": [
        {
          "type": "source",
          "path": "tears-of-steel-aac-128k.mp4"
        }
      ],
      "language": "eng"
    },
    {
      "clips": [
        {
          "type": "source",
          "path": "tears-of-steel-en-hoh.srt"
        }
      ],
      "language": "eng",
      "label": "English (CC)",
      "characteristics": "public.accessibility.transcribes-spoken-dialog"
    },
    {
      "clips": [
        {
          "type": "source",
          "path": "tears-of-steel-en-for.srt"
        }
      ],
      "language": "eng",
      "label":"English (forced)",
      "forced": true
    }
  ]
}
```

#### Known limitations

- For characteristics such as `public.easy-to-read` or `public.accessibility.*`, the label must be explicitly specified. The default label does not take characteristics into account.