### PR TITLE
Ensure that sequence autoselect is enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,20 +528,22 @@ Mandatory fields:
 Optional fields:
 * `id` - a string that identifies the sequence. The id can be retrieved by `$vod_sequence_id`.
 * `language` - a 3-letter (ISO-639-2) language code, this field takes priority over any language
-	specified on the media file (MP4 mdhd atom)
-* `label` - a friendly string that identifies the sequence. If a language is specified,
-	a default label will be automatically derived by it - e.g. if language is `ita`,
-	by default `italiano` will be used as the label.
+	specified on the media file (MP4 mdhd atom).
+* `label` - a friendly string that identifies the sequence. If a language is specified, a default
+	label will be automatically derived by it - e.g. if language is `ita`, by default `italiano`
+	will be used as the label.
 * `roles` - an array of DASH role schemes as defined in ISO/IEC 23009-1 Section 5.8.5.5. For roles
 	such as `caption` or `description`, the label must be explicitly specified. The default label
 	does not take roles into account.
-* `default` - a boolean that sets the value of the DEFAULT attribute of EXT-X-MEDIA tags using this sequence.
-	If not specified, the first EXT-X-MEDIA tag in each group returns DEFAULT=YES, while the others return DEFAULT=NO.
-* `autoselect` - a boolean that sets the value of the AUTOSELECT attribute of EXT-X-MEDIA tags using this sequence.
+* `default` - a boolean that sets the value of the DEFAULT attribute of EXT-X-MEDIA tags using this
+	sequence. If not specified, the first EXT-X-MEDIA tag in each group returns DEFAULT=YES.
+* `autoselect` - a boolean that sets the value of the AUTOSELECT attribute of EXT-X-MEDIA tags using
+	this sequence. If not specified, the EXT-X-MEDIA tags return AUTOSELECT=YES.
 * `characteristics` - a string of HLS characteristics as defined in [RFC 8216 Section 4.3.4.1](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.1).
-	For characteristics such as `public.easy-to-read` or `public.accessibility.*`, the label must be explicitly
-	specified. The default label does not take characteristics into account.
-* `forced` - a boolean that sets the value of the FORCED attribute of EXT-X-MEDIA tags using this sequence.
+	For characteristics such as `public.easy-to-read` or `public.accessibility.*`, the label must be
+	explicitly specified. The default label does not take characteristics into account.
+* `forced` - a boolean that sets the value of the FORCED attribute of EXT-X-MEDIA tags using this
+	sequence.
 * `bitrate` - an object that can be used to set the bitrate for the different media types,
 	in bits per second. For example, `{"v": 900000, "a": 64000}`. If the bitrate is not supplied,
 	nginx-vod-module will estimate it based on the last clip in the sequence.

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -1083,7 +1083,7 @@ ngx_http_vod_parse_uri_path(
 		cur_sequence->tags.label.len = 0;
 		cur_sequence->tags.is_forced = 0;
 		cur_sequence->tags.characteristics.len = 0;
-		cur_sequence->tags.is_autoselect = 0;
+		cur_sequence->tags.is_autoselect = 1;
 		cur_sequence->tags.is_default = -1;
 
 		rc = ngx_array_init(&cur_sequence->tags.roles, r->pool, 1, sizeof(ngx_str_t));

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -1041,7 +1041,7 @@ media_set_parse_sequences(
 		cur_output->tags.label.len = 0;
 		cur_output->tags.is_forced = 0;
 		cur_output->tags.characteristics.len = 0;
-		cur_output->tags.is_autoselect = 0;
+		cur_output->tags.is_autoselect = 1;
 		cur_output->tags.is_default = -1;
 
 		rc = vod_array_init(&cur_output->tags.roles, request_context->pool, 1, sizeof(vod_str_t));


### PR DESCRIPTION
Instruct the client to select by default a rendition matching the current playback environment in the absence of explicit user preference.