### PR TITLE
Ensure that track grouping is correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,16 +532,15 @@ Optional fields:
 * `label` - a friendly string that identifies the sequence. If a language is specified, a default
 	label will be automatically derived by it - e.g. if language is `ita`, by default `italiano`
 	will be used as the label.
-* `roles` - an array of DASH role schemes as defined in ISO/IEC 23009-1 Section 5.8.5.5. For roles
-	such as `caption` or `description`, the label must be explicitly specified. The default label
-	does not take roles into account.
+	> For `roles`, `characteristics`, and `forced`, the label must be explicitly specified. The
+	> default label does not consider them.
+* `roles` - an array of role schemes as defined in [ISO/IEC 23009-1](https://www.iso.org/standard/83314.html)
+	Section 5.8.5.5.
 * `default` - a boolean that sets the value of the DEFAULT attribute of EXT-X-MEDIA tags using this
 	sequence. If not specified, the first EXT-X-MEDIA tag in each group returns DEFAULT=YES.
 * `autoselect` - a boolean that sets the value of the AUTOSELECT attribute of EXT-X-MEDIA tags using
 	this sequence. If not specified, the EXT-X-MEDIA tags return AUTOSELECT=YES.
-* `characteristics` - a string of HLS characteristics as defined in [RFC 8216 Section 4.3.4.1](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.1).
-	For characteristics such as `public.easy-to-read` or `public.accessibility.*`, the label must be
-	explicitly specified. The default label does not take characteristics into account.
+* `characteristics` - a string of characteristics as defined in [RFC 8216 Section 4.3.4.1](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.1).
 * `forced` - a boolean that sets the value of the FORCED attribute of EXT-X-MEDIA tags using this
 	sequence.
 * `bitrate` - an object that can be used to set the bitrate for the different media types,
@@ -550,6 +549,9 @@ Optional fields:
 * `avg_bitrate` - an object that can be used to set the average bitrate for the different media types,
 	in bits per second. See `bitrate` above for a sample object. If specified, the module will use
 	the value to populate the AVERAGE-BANDWIDTH attribute of `#EXT-X-STREAM-INF` in HLS.
+> **Important**: The options `label`, `roles`, `characteristics`, and `forced` are used to group
+> tracks. As HLS does not have the concept of **video** `AdaptationSet`, any use of these options
+> will cause the HLS manifest builder to consider only the **first** video group.
 
 #### Clip (abstract)
 

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -308,6 +308,10 @@ static dash_codec_info_t dash_codecs[VOD_CODEC_ID_COUNT] = {
 static bool_t
 dash_packager_compare_tracks(uintptr_t bitrate_threshold, const media_info_t* mi1, const media_info_t* mi2)
 {
+	uintptr_t i;
+	vod_str_t* role1;
+	vod_str_t* role2;
+
 	if (mi1->bitrate == 0 ||
 		mi2->bitrate == 0 ||
 		mi1->bitrate + bitrate_threshold <= mi2->bitrate ||
@@ -333,7 +337,37 @@ dash_packager_compare_tracks(uintptr_t bitrate_threshold, const media_info_t* mi
 		return TRUE;
 	}
 
-	return vod_str_equals(mi1->tags.label, mi2->tags.label);
+	if (!vod_str_equals(mi1->tags.label, mi2->tags.label)) {
+		return FALSE;
+	}
+
+	if (mi1->tags.is_forced != mi2->tags.is_forced)
+	{
+		return FALSE;
+	}
+
+	if (!vod_str_equals(mi1->tags.characteristics, mi2->tags.characteristics))
+	{
+		return FALSE;
+	}
+
+	if (mi1->tags.roles.nelts != mi2->tags.roles.nelts)
+	{
+		return FALSE;
+	}
+
+	for (i = 0; i < mi1->tags.roles.nelts; i++)
+	{
+		role1 = (vod_str_t*)mi1->tags.roles.elts + i;
+		role2 = (vod_str_t*)mi2->tags.roles.elts + i;
+
+		if (!vod_str_equals(*role1, *role2))
+		{
+			return FALSE;
+		}
+	}
+
+	return TRUE;
 }
 
 static void

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -676,12 +676,10 @@ dash_packager_write_frame_rate(
 static u_char*
 dash_packager_write_roles(u_char* p, media_info_t* media_info)
 {
-	vod_str_t* role = media_info->tags.roles.elts;
-	vod_str_t* last_role = role + media_info->tags.roles.nelts;
-
-	for (; role < last_role; role++)
+	for (uintptr_t i = 0; i < media_info->tags.roles.nelts; i++)
 	{
-		p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_ROLE, role);
+		p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_ROLE,
+			(vod_str_t*)media_info->tags.roles.elts + i);
 	}
 
 	return p;

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -1081,28 +1081,25 @@ media_set_parse_sequences(
 			continue;
 		}
 
-		if (cur_output->tags.lang_str.len != 0)
+		if (cur_output->tags.lang_str.len >= LANG_ISO639_3_LEN)
 		{
-			if (cur_output->tags.lang_str.len >= LANG_ISO639_3_LEN)
+			cur_output->tags.language = lang_parse_iso639_3_code(iso639_3_str_to_int(cur_output->tags.lang_str.data));
+			if (cur_output->tags.language != 0)
 			{
-				cur_output->tags.language = lang_parse_iso639_3_code(iso639_3_str_to_int(cur_output->tags.lang_str.data));
-				if (cur_output->tags.language != 0)
-				{
-					cur_output->tags.lang_str.data = (u_char *)lang_get_rfc_5646_name(cur_output->tags.language);
-					cur_output->tags.lang_str.len = ngx_strlen(cur_output->tags.lang_str.data);
-				}
+				cur_output->tags.lang_str.data = (u_char *)lang_get_rfc_5646_name(cur_output->tags.language);
+				cur_output->tags.lang_str.len = ngx_strlen(cur_output->tags.lang_str.data);
 			}
+		}
 
-			if (cur_output->tags.label.len == 0)
+		if (cur_output->tags.label.len == 0)
+		{
+			if (cur_output->tags.language != 0)
 			{
-				if (cur_output->tags.language != 0)
-				{
-					lang_get_native_name(cur_output->tags.language, &cur_output->tags.label);
-				}
-				else
-				{
-					cur_output->tags.label = cur_output->tags.lang_str;
-				}
+				lang_get_native_name(cur_output->tags.language, &cur_output->tags.label);
+			}
+			else
+			{
+				cur_output->tags.label = cur_output->tags.lang_str;
 			}
 		}
 


### PR DESCRIPTION
Address limitations introduced via #5 and #6. Now `roles`, `characteristics`, and `forced` have their own track group. 

#### Known limitations

- Some player implementations rely on different `label`, therefore it's advised to manually set the `label` when using `roles`, `characteristics`, or `forced` for **non-video** tracks.