### PR TITLE
Improve compliance with DASH specification

### DIFF
--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -309,7 +309,7 @@ static dash_codec_info_t dash_codecs[VOD_CODEC_ID_COUNT] = {
 static bool_t
 dash_packager_compare_tracks(uintptr_t bitrate_threshold, const media_info_t* mi1, const media_info_t* mi2)
 {
-	uintptr_t i;
+	uint32_t role_index;
 	vod_str_t* role1;
 	vod_str_t* role2;
 
@@ -357,10 +357,10 @@ dash_packager_compare_tracks(uintptr_t bitrate_threshold, const media_info_t* mi
 		return FALSE;
 	}
 
-	for (i = 0; i < mi1->tags.roles.nelts; i++)
+	for (role_index = 0; role_index < mi1->tags.roles.nelts; role_index++)
 	{
-		role1 = (vod_str_t*)mi1->tags.roles.elts + i;
-		role2 = (vod_str_t*)mi2->tags.roles.elts + i;
+		role1 = (vod_str_t*)mi1->tags.roles.elts + role_index;
+		role2 = (vod_str_t*)mi2->tags.roles.elts + role_index;
 
 		if (!vod_str_equals(*role1, *role2))
 		{
@@ -711,10 +711,10 @@ dash_packager_write_frame_rate(
 static u_char*
 dash_packager_write_roles(u_char* p, media_info_t* media_info)
 {
-	for (uintptr_t i = 0; i < media_info->tags.roles.nelts; i++)
+	for (uint32_t role_index = 0; role_index < media_info->tags.roles.nelts; role_index++)
 	{
 		p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_ROLE,
-			(vod_str_t*)media_info->tags.roles.elts + i);
+			(vod_str_t*)media_info->tags.roles.elts + role_index);
 	}
 
 	return p;
@@ -1493,7 +1493,7 @@ dash_packager_build_mpd(
 			{
 			case MEDIA_TYPE_AUDIO:
 			case MEDIA_TYPE_SUBTITLE:
-				cur_track = (*adaptation_set->first) + filtered_clip_offset;
+			cur_track = (*adaptation_set->first) + filtered_clip_offset;
 				result_size += cur_track->media_info.tags.label.len + cur_track->media_info.tags.lang_str.len;
 				break;
 			}

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -61,6 +61,7 @@
 	"        id=\"%uD\"\n"														\
 	"        group=\"1\"\n"														\
 	"        contentType=\"video\"\n"											\
+	"        lang=\"%V\"\n"														\
 	"        segmentAlignment=\"true\"\n"										\
 	"        maxWidth=\"%uD\"\n"												\
 	"        maxHeight=\"%uD\"\n"												\
@@ -906,6 +907,7 @@ dash_packager_write_mpd_period(
 			p = vod_sprintf(p,
 				VOD_DASH_MANIFEST_ADAPTATION_HEADER_VIDEO,
 				adapt_id++,
+				&reference_track->media_info.tags.lang_str,
 				max_width,
 				max_height,
 				&frame_rate);
@@ -1439,7 +1441,7 @@ dash_packager_build_mpd(
 	base_period_size =
 		sizeof(VOD_DASH_MANIFEST_PERIOD_HEADER_START_DURATION) - 1 + 5 * VOD_INT32_LEN +
 			// video adaptations
-			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_VIDEO) - 1 + 3 * VOD_INT32_LEN + VOD_DASH_MAX_FRAME_RATE_LEN +
+			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_VIDEO) - 1 + 3 * VOD_INT32_LEN + LANG_ISO639_3_LEN + VOD_DASH_MAX_FRAME_RATE_LEN +
 			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_ROLE) - 1 + MAX_ROLE_SIZE) * 3 +
 			sizeof(VOD_DASH_MANIFEST_ADAPTATION_FOOTER) - 1) * context.adaptation_sets.count[ADAPTATION_TYPE_VIDEO] +
 			// video representations

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -88,7 +88,6 @@
 	"    <AdaptationSet\n"														\
 	"        id=\"%uD\"\n"														\
 	"        lang=\"%V\"\n"														\
-	"        label=\"%V\"\n"													\
 	"        segmentAlignment=\"true\">\n"
 
 // TODO: value should be the number of channels ?
@@ -114,8 +113,7 @@
 #define VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_SMPTE_TT					\
 	"    <AdaptationSet\n"														\
 	"        contentType=\"text\"\n"											\
-	"        lang=\"%V\"\n"														\
-	"        label=\"%V\">\n"
+	"        lang=\"%V\">\n"
 
 #define VOD_DASH_MANIFEST_REPRESENTATION_HEADER_SUBTITLE_SMPTE_TT				\
 	"      <Representation\n"													\
@@ -132,10 +130,9 @@
 	"    <AdaptationSet\n"														\
 	"        contentType=\"text\"\n"											\
 	"        lang=\"%V\"\n"														\
-	"        label=\"%V\"\n"													\
 	"        mimeType=\"text/vtt\">\n"
 
-#define VOD_DASH_MANIFEST_REPRESENTATION_SUBTITLE_VTT					\
+#define VOD_DASH_MANIFEST_REPRESENTATION_SUBTITLE_VTT							\
 	"      <Representation\n"													\
 	"          id=\"textstream_%s_%uD\"\n"										\
 	"          bandwidth=\"0\">\n"												\
@@ -906,12 +903,11 @@ dash_packager_write_mpd_period(
 
 		case MEDIA_TYPE_AUDIO:
 			reference_track = (*adaptation_set->first) + filtered_clip_offset;
-			if (reference_track->media_info.tags.lang_str.len > 0 || reference_track->media_info.tags.label.len > 0)
+			if (reference_track->media_info.tags.lang_str.len > 0)
 			{
 				p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO_LANG,
 					adapt_id++,
-					&reference_track->media_info.tags.lang_str,
-					&reference_track->media_info.tags.label);
+					&reference_track->media_info.tags.lang_str);
 			}
 			else
 			{
@@ -937,8 +933,7 @@ dash_packager_write_mpd_period(
 			{
 				reference_track = (*adaptation_set->first) + filtered_clip_offset;
 				p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_SMPTE_TT,
-					&reference_track->media_info.tags.lang_str,
-					&reference_track->media_info.tags.label);
+					&reference_track->media_info.tags.lang_str);
 				break;
 			}
 
@@ -968,8 +963,7 @@ dash_packager_write_mpd_period(
 			}
 
 			p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT,
-				&cur_track->media_info.tags.lang_str,
-				&cur_track->media_info.tags.label);
+				&cur_track->media_info.tags.lang_str);
 
 			p = dash_packager_write_roles(p, &cur_track->media_info);
 
@@ -1455,7 +1449,7 @@ dash_packager_build_mpd(
 	case SUBTITLE_FORMAT_WEBVTT:
 		base_period_size +=
 			// subtitle adaptations
-			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT) - 1 + LANG_ISO639_3_LEN + VOD_INT32_LEN +
+			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT) - 1 + LANG_ISO639_3_LEN +
 			// subtitle roles
 			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_ROLE) - 1 + MAX_ROLE_SIZE) * 3 +
 			// subtitle representation
@@ -1467,7 +1461,7 @@ dash_packager_build_mpd(
 	default: // SUBTITLE_FORMAT_SMPTE_TT
 		base_period_size +=
 			// subtitle adaptations
-			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_SMPTE_TT) - 1 +
+			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_SMPTE_TT) - 1 + LANG_ISO639_3_LEN +
 			sizeof(VOD_DASH_MANIFEST_ADAPTATION_FOOTER) - 1) * context.adaptation_sets.count[ADAPTATION_TYPE_SUBTITLE] +
 			// subtitle representations
 			(sizeof(VOD_DASH_MANIFEST_REPRESENTATION_HEADER_SUBTITLE_SMPTE_TT) - 1 + MAX_TRACK_SPEC_LENGTH +

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -60,6 +60,7 @@
 	"    <AdaptationSet\n"														\
 	"        id=\"%uD\"\n"														\
 	"        group=\"1\"\n"														\
+	"        contentType=\"video\"\n"											\
 	"        segmentAlignment=\"true\"\n"										\
 	"        maxWidth=\"%uD\"\n"												\
 	"        maxHeight=\"%uD\"\n"												\
@@ -84,12 +85,14 @@
 	"    <AdaptationSet\n"														\
 	"        id=\"%uD\"\n"														\
 	"        group=\"2\"\n"														\
+	"        contentType=\"audio\"\n"											\
 	"        segmentAlignment=\"true\">\n"
 
 #define VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO_LANG							\
 	"    <AdaptationSet\n"														\
 	"        id=\"%uD\"\n"														\
 	"        group=\"2\"\n"														\
+	"        contentType=\"audio\"\n"											\
 	"        lang=\"%V\"\n"														\
 	"        segmentAlignment=\"true\">\n"
 

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -87,13 +87,6 @@
 	"        id=\"%uD\"\n"														\
 	"        group=\"2\"\n"														\
 	"        contentType=\"audio\"\n"											\
-	"        segmentAlignment=\"true\">\n"
-
-#define VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO_LANG							\
-	"    <AdaptationSet\n"														\
-	"        id=\"%uD\"\n"														\
-	"        group=\"2\"\n"														\
-	"        contentType=\"audio\"\n"											\
 	"        lang=\"%V\"\n"														\
 	"        segmentAlignment=\"true\">\n"
 
@@ -915,17 +908,9 @@ dash_packager_write_mpd_period(
 
 		case MEDIA_TYPE_AUDIO:
 			reference_track = (*adaptation_set->first) + filtered_clip_offset;
-			if (reference_track->media_info.tags.lang_str.len > 0)
-			{
-				p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO_LANG,
-					adapt_id++,
-					&reference_track->media_info.tags.lang_str);
-			}
-			else
-			{
-				p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO,
-					adapt_id++);
-			}
+			p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO,
+				adapt_id++,
+				&reference_track->media_info.tags.lang_str);
 
 			if (reference_track->media_info.codec_id == VOD_CODEC_ID_EAC3)
 			{
@@ -1448,7 +1433,7 @@ dash_packager_build_mpd(
 			(sizeof(VOD_DASH_MANIFEST_REPRESENTATION_HEADER_VIDEO) - 1 + MAX_TRACK_SPEC_LENGTH + MAX_MIME_TYPE_SIZE + MAX_CODEC_NAME_SIZE + 3 * VOD_INT32_LEN + VOD_DASH_MAX_FRAME_RATE_LEN +
 			sizeof(VOD_DASH_MANIFEST_REPRESENTATION_FOOTER) - 1) * media_set->track_count[MEDIA_TYPE_VIDEO] +
 			// audio adaptations
-			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO_LANG) - 1 + sizeof(VOD_DASH_MANIFEST_AUDIO_CHANNEL_CONFIG_EAC3) - 1 + 2 * VOD_INT32_LEN +
+			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO) - 1 + sizeof(VOD_DASH_MANIFEST_AUDIO_CHANNEL_CONFIG_EAC3) - 1 + 2 * VOD_INT32_LEN +
 			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_ROLE) - 1 + MAX_ROLE_SIZE) * 3 +
 			sizeof(VOD_DASH_MANIFEST_ADAPTATION_FOOTER) - 1) * context.adaptation_sets.count[ADAPTATION_TYPE_AUDIO] +
 			// audio representations

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -59,6 +59,7 @@
 #define VOD_DASH_MANIFEST_ADAPTATION_HEADER_VIDEO								\
 	"    <AdaptationSet\n"														\
 	"        id=\"%uD\"\n"														\
+	"        group=\"1\"\n"														\
 	"        segmentAlignment=\"true\"\n"										\
 	"        maxWidth=\"%uD\"\n"												\
 	"        maxHeight=\"%uD\"\n"												\
@@ -82,11 +83,13 @@
 #define VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO								\
 	"    <AdaptationSet\n"														\
 	"        id=\"%uD\"\n"														\
+	"        group=\"2\"\n"														\
 	"        segmentAlignment=\"true\">\n"
 
 #define VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO_LANG							\
 	"    <AdaptationSet\n"														\
 	"        id=\"%uD\"\n"														\
+	"        group=\"2\"\n"														\
 	"        lang=\"%V\"\n"														\
 	"        segmentAlignment=\"true\">\n"
 
@@ -113,6 +116,7 @@
 #define VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_SMPTE_TT					\
 	"    <AdaptationSet\n"														\
 	"        id=\"%uD\"\n"														\
+	"        group=\"3\"\n"														\
 	"        contentType=\"text\"\n"											\
 	"        lang=\"%V\">\n"
 
@@ -130,6 +134,7 @@
 #define VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT						\
 	"    <AdaptationSet\n"														\
 	"        id=\"%uD\"\n"														\
+	"        group=\"3\"\n"														\
 	"        contentType=\"text\"\n"											\
 	"        lang=\"%V\"\n"														\
 	"        mimeType=\"text/vtt\">\n"

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -112,6 +112,7 @@
 
 #define VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_SMPTE_TT					\
 	"    <AdaptationSet\n"														\
+	"        id=\"%uD\"\n"														\
 	"        contentType=\"text\"\n"											\
 	"        lang=\"%V\">\n"
 
@@ -128,6 +129,7 @@
 
 #define VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT						\
 	"    <AdaptationSet\n"														\
+	"        id=\"%uD\"\n"														\
 	"        contentType=\"text\"\n"											\
 	"        lang=\"%V\"\n"														\
 	"        mimeType=\"text/vtt\">\n"
@@ -933,6 +935,7 @@ dash_packager_write_mpd_period(
 			{
 				reference_track = (*adaptation_set->first) + filtered_clip_offset;
 				p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_SMPTE_TT,
+					adapt_id++,
 					&reference_track->media_info.tags.lang_str);
 				break;
 			}
@@ -963,6 +966,7 @@ dash_packager_write_mpd_period(
 			}
 
 			p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT,
+				adapt_id++,
 				&cur_track->media_info.tags.lang_str);
 
 			p = dash_packager_write_roles(p, &cur_track->media_info);
@@ -1449,7 +1453,7 @@ dash_packager_build_mpd(
 	case SUBTITLE_FORMAT_WEBVTT:
 		base_period_size +=
 			// subtitle adaptations
-			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT) - 1 + LANG_ISO639_3_LEN +
+			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_VTT) - 1 + VOD_INT32_LEN + LANG_ISO639_3_LEN +
 			// subtitle roles
 			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_ROLE) - 1 + MAX_ROLE_SIZE) * 3 +
 			// subtitle representation
@@ -1461,7 +1465,7 @@ dash_packager_build_mpd(
 	default: // SUBTITLE_FORMAT_SMPTE_TT
 		base_period_size +=
 			// subtitle adaptations
-			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_SMPTE_TT) - 1 + LANG_ISO639_3_LEN +
+			(sizeof(VOD_DASH_MANIFEST_ADAPTATION_HEADER_SUBTITLE_SMPTE_TT) - 1 + VOD_INT32_LEN + LANG_ISO639_3_LEN +
 			sizeof(VOD_DASH_MANIFEST_ADAPTATION_FOOTER) - 1) * context.adaptation_sets.count[ADAPTATION_TYPE_SUBTITLE] +
 			// subtitle representations
 			(sizeof(VOD_DASH_MANIFEST_REPRESENTATION_HEADER_SUBTITLE_SMPTE_TT) - 1 + MAX_TRACK_SPEC_LENGTH +

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -41,8 +41,6 @@
 #define M3U8_VIDEO_RANGE_SDR ",VIDEO-RANGE=SDR"
 #define M3U8_VIDEO_RANGE_PQ ",VIDEO-RANGE=PQ"
 
-#define MAX_CHARACTERISTICS_SIZE (128)
-
 // constants
 static const u_char m3u8_header[] = "#EXTM3U\n";
 static const u_char m3u8_footer[] = "#EXT-X-ENDLIST\n";
@@ -912,7 +910,6 @@ m3u8_builder_ext_x_media_tags_get_size(
 	adaptation_set_t* last_adaptation_set;
 	adaptation_set_t* adaptation_set;
 	media_track_t* cur_track;
-	size_t label_len;
 	size_t result;
 
 	result =
@@ -923,7 +920,7 @@ m3u8_builder_ext_x_media_tags_get_size(
 		sizeof(M3U8_EXT_MEDIA_LANG) - 1 +
 		sizeof(M3U8_EXT_MEDIA_DEFAULT) - 1 +
 		sizeof(M3U8_EXT_MEDIA_AUTOSELECT) - 1 +
-		sizeof(M3U8_EXT_MEDIA_CHARACTERISTICS) - 1 + MAX_CHARACTERISTICS_SIZE +
+		sizeof(M3U8_EXT_MEDIA_CHARACTERISTICS) - 1 +
 		sizeof(M3U8_EXT_MEDIA_FORCED) - 1 +
 		sizeof(M3U8_EXT_MEDIA_CHANNELS) - 1 + VOD_INT32_LEN +
 		sizeof(M3U8_EXT_MEDIA_URI) - 1 +
@@ -936,8 +933,9 @@ m3u8_builder_ext_x_media_tags_get_size(
 	{
 		cur_track = adaptation_set->first[0];
 
-		label_len = cur_track->media_info.tags.label.len;
-		result += vod_max(label_len, default_label.len) + cur_track->media_info.tags.lang_str.len;
+		result += vod_max(cur_track->media_info.tags.label.len, default_label.len) +
+			cur_track->media_info.tags.lang_str.len +
+			cur_track->media_info.tags.characteristics.len;
 
 		if (base_url->len != 0)
 		{

--- a/vod/manifest_utils.c
+++ b/vod/manifest_utils.c
@@ -459,9 +459,9 @@ track_group_key_get_hash(track_group_key_t* key)
 		vod_crc32_short(key->tags.characteristics.data, key->tags.characteristics.len);
 
 	vod_str_t* role;
-	for (uintptr_t i = 0; i < key->tags.roles.nelts; i++)
+	for (uint32_t role_index = 0; role_index < key->tags.roles.nelts; role_index++)
 	{
-		role = (vod_str_t*)key->tags.roles.elts + i;
+		role = (vod_str_t*)key->tags.roles.elts + role_index;
 		hash += vod_crc32_short(role->data, role->len);
 	}
 
@@ -471,7 +471,7 @@ track_group_key_get_hash(track_group_key_t* key)
 static int8_t
 track_group_key_compare(track_group_key_t* key1, track_group_key_t* key2)
 {
-	uintptr_t i;
+	uint32_t role_index;
 	vod_str_t* role1;
 	vod_str_t* role2;
 	int8_t rc;
@@ -520,10 +520,10 @@ track_group_key_compare(track_group_key_t* key1, track_group_key_t* key2)
 		return key1->tags.roles.nelts < key2->tags.roles.nelts ? -1 : 1;
 	}
 
-	for (i = 0; i < key1->tags.roles.nelts; i++)
+	for (role_index = 0; role_index < key1->tags.roles.nelts; role_index++)
 	{
-		role1 = (vod_str_t*)key1->tags.roles.elts + i;
-		role2 = (vod_str_t*)key2->tags.roles.elts + i;
+		role1 = (vod_str_t*)key1->tags.roles.elts + role_index;
+		role2 = (vod_str_t*)key2->tags.roles.elts + role_index;
 
 		if (role1->len != role2->len)
 		{


### PR DESCRIPTION
Summary of the changes:

- Add `group` attribute to all `AdaptationSet`
- Add missing `id`, `lang`, and `contentType` attributes to `AdaptationSet`
- Remove non-standard `label` attribute from `AdaptationSet`
- Add spec-compliant `Label` to `AdaptationSet`
- Fix manifest memory size allocation

> **Note**: The module now has basic support for localized video in DASH.