### PR TITLE
Ensure that clock_gettime check works

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ docker image build -t nginx-vod-module .
 docker container run --rm -it -p 8000:80 nginx-vod-module
 ```
 
-The sample configuration files are available in the `sample` folder. You can customize the
-configurations based on your specific requirements.
+The sample configuration files are available in the [`sample` folder](./sample). You can customize
+the configurations based on your specific requirements.
 
 ### URL structure
 

--- a/config
+++ b/config
@@ -125,10 +125,10 @@ ngx_feature_test="iconv_open(NULL, NULL);"
 ngx_feature="clock_gettime()"
 ngx_feature_name="NGX_HAVE_CLOCK_GETTIME"
 ngx_feature_run=no
-ngx_feature_incs="#include <sched.h>"
+ngx_feature_incs="#include <time.h>"
 ngx_feature_path=
 ngx_feature_libs=
-ngx_feature_test="clock_gettime()"
+ngx_feature_test="clockid_t c; clock_gettime(c, NULL)"
 . auto/feature
 
 if [ $ngx_found != yes ]; then


### PR DESCRIPTION
The `clock_gettime()` function is provided by `time.h` and expects two arguments.