### PR TITLE
Fix DASH representation ID for single sequence

### DIFF
--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -407,17 +407,16 @@ dash_packager_get_track_spec(
 	{
 		if (sequence->id.len != 0 && sequence->id.len < VOD_INT32_LEN)
 		{
-			p = vod_sprintf(p, "s%V", &sequence->id);
+			p = vod_sprintf(p, "s%V-", &sequence->id);
 		}
 		else
 		{
-			p = vod_sprintf(p, "f%uD", sequence->index + 1);
+			p = vod_sprintf(p, "f%uD-", sequence->index + 1);
 		}
 	}
 
 	if (track->media_info.media_type <= MEDIA_TYPE_AUDIO)
 	{
-		*p++ = '-';
 		*p++ = media_type_letter[track->media_info.media_type];
 		p = vod_sprintf(p, "%uD", track->index + 1);
 	}


### PR DESCRIPTION
Address the issue introduced via #17. When a single sequence is defined, the DASH representation ID is straightforward and does not include the sequence index or sequence ID.

Fixes #21