### PR TITLE
Ensure that DASH request version is correct

### DIFF
--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -417,7 +417,7 @@ dash_packager_get_track_spec(
 	if (track->media_info.media_type <= MEDIA_TYPE_AUDIO)
 	{
 		*p++ = media_type_letter[track->media_info.media_type];
-		p = vod_sprintf(p, "%uD", track->index + 1);
+		p = vod_sprintf(p, "%uD-x3", track->index + 1); // TODO: remove -xN in the future
 	}
 
 	result->len = p - result->data;


### PR DESCRIPTION
Address regression introduced via #17. Users reported playback startup failures, stalling, and infinite buffering on Sony PS4 and Sky Q.