### PR TITLE
Improve sample cache control

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN /nginx-vod-module/scripts/build_basic.sh \
 		--without-http_mirror_module \
 		--without-http_autoindex_module \
 		--without-http_geo_module \
-		--without-http_map_module \
 		--without-http_split_clients_module \
 		--without-http_referer_module \
 		--without-http_fastcgi_module \

--- a/sample/expires.conf
+++ b/sample/expires.conf
@@ -1,3 +1,0 @@
-add_header Cache-Control 'public, immutable';
-
-expires 1y;

--- a/sample/nginx.conf
+++ b/sample/nginx.conf
@@ -38,6 +38,11 @@ http {
 		keepalive_timeout 5s;
 	}
 
+	map $status $cache_control_directives {
+		~^2 'public, max-age=31536000, immutable';
+		default 'public, max-age=3';
+	}
+
 	server {
 		listen 80 default_server backlog=65536 reuseport;
 		listen [::]:80 default_server backlog=65536 reuseport;
@@ -116,16 +121,16 @@ http {
 
 		location ~ ^/hls/clear/(?<playback_token>[^/]+)/ {
 			vod hls;
+			add_header Cache-Control $cache_control_directives always;
 			include cors.conf;
-			include expires.conf;
 		}
 
 		location ~ ^/hls/cbcs/(?<playback_token>[^/]+)/ {
 			vod hls;
 			vod_drm_enabled on;
 			vod_hls_encryption_method sample-aes;
+			add_header Cache-Control $cache_control_directives always;
 			include cors.conf;
-			include expires.conf;
 		}
 
 		vod_dash_profiles 'urn:mpeg:dash:profile:isoff-live:2011';
@@ -134,15 +139,15 @@ http {
 
 		location ~ ^/dash/clear/(?<playback_token>[^/]+)/ {
 			vod dash;
+			add_header Cache-Control $cache_control_directives always;
 			include cors.conf;
-			include expires.conf;
 		}
 
 		location ~ ^/dash/cenc/(?<playback_token>[^/]+)/ {
 			vod dash;
 			vod_drm_enabled on;
+			add_header Cache-Control $cache_control_directives always;
 			include cors.conf;
-			include expires.conf;
 		}
 
 		vod_performance_counters performance_count;


### PR DESCRIPTION
Add `Cache-Control` for non-2xx responses to mitigate transient upstream errors (backpressure handling).