### PR TITLE
Update nginx to v1.28.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: nginx-vod-module
       - run: mkdir nginx
-      - run: curl -s https://nginx.org/download/nginx-1.27.5.tar.gz | tar -xz --strip-components 1 -C nginx
+      - run: curl -s https://nginx.org/download/nginx-1.28.0.tar.gz | tar -xz --strip-components 1 -C nginx
       - working-directory: nginx
         run: |
           ../nginx-vod-module/scripts/build_basic.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add \
 		fdk-aac-dev \
 		openssl-dev \
 	&& mkdir /nginx \
-	&& wget -qO- https://nginx.org/download/nginx-1.27.5.tar.gz | tar -xz --strip-components 1 -C /nginx
+	&& wget -qO- https://nginx.org/download/nginx-1.28.0.tar.gz | tar -xz --strip-components 1 -C /nginx
 
 COPY --exclude=sample . /nginx-vod-module
 


### PR DESCRIPTION
Update NGINX to latest stable [v1.28.0](https://nginx.org/en/CHANGES-1.28). No impacting changes introduced.