### PR TITLE
Allow HLS version tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1757,6 +1757,25 @@ Sets the encryption method of HLS segments.
 When enabled the server returns the audio stream in separate segments than the ones used by the
 video stream (using `#EXT-X-MEDIA`).
 
+#### vod_hls_version
+
+- **syntax**: `vod_hls_version :version`
+- **default**: `4`
+- **context**: `http`, `server`, `location`
+
+Sets the version of the manifest. See
+[RFC 8216 Section 7](https://datatracker.ietf.org/doc/html/rfc8216#section-7) for protocol version
+compatibility.
+
+> [!IMPORTANT]
+> The mimimum version required by this module is `3`.
+
+> [!TIP]
+> For maximum compatibility, set the version to the lowest value that allows the required features
+> for playback. While this is not strictly spec-compliant, most clients are lenient and will ignore
+> unknown or unsupported tags. However, advanced features (such as fMP4) may not be recognized or
+> used by clients unless the version is set to the minimum required for those features.
+
 #### vod_hls_container_format
 
 - **syntax**: `vod_hls_container_format mpegts | fmp4 | auto`

--- a/ngx_http_vod_hls_commands.h
+++ b/ngx_http_vod_hls_commands.h
@@ -44,6 +44,13 @@
 	NULL },
 #endif // NGX_HAVE_OPENSSL_EVP
 
+	{ ngx_string("vod_hls_version"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_enum_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, m3u8_config.m3u8_version),
+	NULL },
+
 	{ ngx_string("vod_hls_container_format"),
 	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
 	ngx_conf_set_enum_slot,

--- a/vod/hls/m3u8_builder.h
+++ b/vod/hls/m3u8_builder.h
@@ -19,7 +19,7 @@ enum {
 };
 
 typedef struct {
-	uint8_t m3u8_version;
+	int8_t m3u8_version;
 	vod_uint_t container_format;
 	u_char iframes_m3u8_header[MAX_IFRAMES_M3U8_HEADER_SIZE];
 	size_t iframes_m3u8_header_len;
@@ -61,9 +61,6 @@ vod_status_t m3u8_builder_build_iframe_playlist(
 	media_set_t* media_set,
 	vod_str_t* result);
 
-void m3u8_builder_init_config(
-	m3u8_config_t* conf,
-	uint32_t max_segment_duration,
-	hls_encryption_type_t encryption_method);
+void m3u8_builder_init_config(m3u8_config_t* conf, uint32_t max_segment_duration);
 
 #endif // __M3U8_BUILDER_H__


### PR DESCRIPTION
Recent changes via #32 and #26 made the module too opinionated regarding which HLS version should be used, which restricted certain use cases.

The HLS version can now be explicitly set using the vod_hls_version directive. A warning will be logged if a potentially incorrect version is detected.

This change provides more flexibility for different requirements and avoids hardcoded assumptions about the HLS version.