### PR TITLE
Fix regression in DRM-enabled HLS builder

### DIFF
--- a/sample/nginx.conf
+++ b/sample/nginx.conf
@@ -39,7 +39,7 @@ http {
 	}
 
 	map $status $cache_control_directives {
-		~^2 'public, max-age=31536000, immutable';
+		~^2|304 'public, max-age=31536000, immutable';
 		default 'public, max-age=3';
 	}
 

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -654,12 +654,12 @@ m3u8_builder_build_index_playlist(
 
 		if (conf->encryption_key_format.len != 0)
 		{
-			p = vod_sprintf(p, m3u8_key_keyformat, conf->encryption_key_format);
+			p = vod_sprintf(p, m3u8_key_keyformat, &conf->encryption_key_format);
 		}
 
 		if (conf->encryption_key_format_versions.len != 0)
 		{
-			p = vod_sprintf(p, m3u8_key_keyformatversions, conf->encryption_key_format_versions);
+			p = vod_sprintf(p, m3u8_key_keyformatversions, &conf->encryption_key_format_versions);
 		}
 
 		*p++ = '\n';


### PR DESCRIPTION
Address issue introduced via #33. The `%V` format specifier expects a pointer. Additionally, ensures that `304` is cached as `2xx`.