### PR TITLE
Add video range HLG support

### DIFF
--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -47,6 +47,7 @@ static const char m3u8_stream_inf_subtitles_group[] = ",SUBTITLES=\"subs%uD\"";
 static const char m3u8_stream_inf_closed_captions_group[] = ",CLOSED-CAPTIONS=\"cc%uD\"";
 static const u_char m3u8_stream_inf_no_closed_captions[] = ",CLOSED-CAPTIONS=NONE";
 static const u_char m3u8_stream_inf_video_range_sdr[] = ",VIDEO-RANGE=SDR";
+static const u_char m3u8_stream_inf_video_range_hlg[] = ",VIDEO-RANGE=HLG";
 static const u_char m3u8_stream_inf_video_range_pq[] = ",VIDEO-RANGE=PQ";
 
 static const char m3u8_iframe_stream_inf[] = "#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=%uD,RESOLUTION=%uDx%uD,CODECS=\"%V\",URI=\"";
@@ -1084,12 +1085,19 @@ m3u8_builder_write_video_range(u_char* p, media_info_t* media_info)
 	switch (media_info->u.video.transfer_characteristics)
 	{
 	case 1:
-		p = vod_copy(p, m3u8_stream_inf_video_range_sdr, sizeof(m3u8_stream_inf_video_range_sdr) - 1);
+		p = vod_copy(p,
+			m3u8_stream_inf_video_range_sdr,
+			sizeof(m3u8_stream_inf_video_range_sdr) - 1);
 		break;
 
 	case 16:
-	case 18:
 		p = vod_copy(p, m3u8_stream_inf_video_range_pq, sizeof(m3u8_stream_inf_video_range_pq) - 1);
+		break;
+
+	case 18:
+		p = vod_copy(p,
+			m3u8_stream_inf_video_range_hlg,
+			sizeof(m3u8_stream_inf_video_range_hlg) - 1);
 		break;
 	}
 


### PR DESCRIPTION
Enhances the existing `VIDEO-RANGE` attribute support, aligning it with the HLS version 10 specification.

In HLS version 8, `VIDEO-RANGE` was introduced with two valid values: `SDR` and `PQ`. `SDR` applied when all video used TransferCharacteristics code point `1`, while `PQ` applied if any content used code point `16` or `18`. In all other cases, the attribute must be omitted.

In HLS version 10, the the valid values were expanded to include `HLG`, and the definition of `SDR` was broadened to include additional code points (`1`, `6`, `13`, `14`, `15`). `HLG` is required when video is encoded using code point `18` or mixed with `SDR` content. `PQ` applies when video uses code point `16` or is mixed with `SDR` or `HLG` content.

Its absence implies a default value of `SDR`.