### PR TITLE
Add multi-DRM support for HLS SAMPLE-AES-CTR

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,7 @@ Apple FairPlay HLS:
 location ~ ^/hls/cbcs/(?<playback_token>[^/]+)/ {
   vod hls;
 
+  vod_hls_version 5;
   vod_hls_encryption_method sample-aes;
   vod_hls_encryption_key_uri 'skd://$vod_set_id';
   vod_hls_encryption_key_format 'com.apple.streamingkeydelivery';

--- a/README.md
+++ b/README.md
@@ -872,7 +872,7 @@ Common Encryption HLS:
 location ~ ^/hls/cenc/(?<playback_token>[^/]+)/ {
   vod hls;
 
-  vod_hls_encryption_method sample-aes-cenc;
+  vod_hls_encryption_method sample-aes-ctr;
   vod_hls_encryption_key_format 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed';
   vod_hls_encryption_key_format_versions '1';
 
@@ -1742,7 +1742,7 @@ URLs.
 
 #### vod_hls_encryption_method
 
-- **syntax**: `vod_hls_encryption_method none | aes-128 | sample-aes | sample-aes-cenc`
+- **syntax**: `vod_hls_encryption_method none | aes-128 | sample-aes | sample-aes-ctr`
 - **default**: `none`
 - **context**: `http`, `server`, `location`
 

--- a/README.md
+++ b/README.md
@@ -872,9 +872,8 @@ Common Encryption HLS:
 location ~ ^/hls/cenc/(?<playback_token>[^/]+)/ {
   vod hls;
 
+  vod_hls_version 6;
   vod_hls_encryption_method sample-aes-ctr;
-  vod_hls_encryption_key_format 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed';
-  vod_hls_encryption_key_format_versions '1';
 
   vod_drm_enabled on;
   vod_drm_request_uri '/drm/$playback_token';

--- a/config
+++ b/config
@@ -64,6 +64,7 @@ VOD_FEATURE_SRCS="                                      \
     $ngx_addon_dir/vod/mp4/mp4_cenc_decrypt.c           \
     $ngx_addon_dir/vod/mp4/mp4_cenc_encrypt.c           \
     $ngx_addon_dir/vod/mp4/mp4_cenc_passthrough.c       \
+    $ngx_addon_dir/vod/mp4/mp4_pssh.c                   \
     "
 
 VOD_FEATURE_DEPS="                                      \
@@ -77,6 +78,7 @@ VOD_FEATURE_DEPS="                                      \
     $ngx_addon_dir/vod/mp4/mp4_cenc_decrypt.h           \
     $ngx_addon_dir/vod/mp4/mp4_cenc_encrypt.h           \
     $ngx_addon_dir/vod/mp4/mp4_cenc_passthrough.h       \
+    $ngx_addon_dir/vod/mp4/mp4_pssh.h                   \
     "
 
 if [ $OPENSSL = NONE ]; then

--- a/demo/drm/tears-of-steel
+++ b/demo/drm/tears-of-steel
@@ -6,7 +6,7 @@
     "pssh": [
       {
         "uuid": "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed",
-        "data": "CAESEDQiJesToUme+oVHeWUeoJkiCrXmq7PqH/rLXno="
+        "data": "CAESEDQiJesToUme+oVHeWUeoJkiDnRlYXJzLW9mLXN0ZWVs"
       },
       {
         "uuid": "9a04f079-9840-4286-ab92-e65be0885f95",

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -63,7 +63,7 @@ ngx_conf_enum_t  hls_encryption_methods[] = {
 	{ ngx_string("none"), HLS_ENC_NONE },
 	{ ngx_string("aes-128"), HLS_ENC_AES_128 },
 	{ ngx_string("sample-aes"), HLS_ENC_SAMPLE_AES },
-	{ ngx_string("sample-aes-cenc"), HLS_ENC_SAMPLE_AES_CENC },
+	{ ngx_string("sample-aes-cenc"), HLS_ENC_SAMPLE_AES_CTR },
 	{ ngx_null_string, 0 }
 };
 
@@ -88,7 +88,7 @@ ngx_http_vod_hls_get_container_format(
 
 	track = media_set->filtered_tracks;
 	if ((track->media_info.media_type == MEDIA_TYPE_VIDEO && track->media_info.codec_id != VOD_CODEC_ID_AVC) ||
-		conf->encryption_method == HLS_ENC_SAMPLE_AES_CENC)
+		conf->encryption_method == HLS_ENC_SAMPLE_AES_CTR)
 	{
 		return HLS_CONTAINER_FMP4;
 	}
@@ -624,7 +624,7 @@ ngx_http_vod_hls_init_ts_frame_processor(
 		return rc;
 	}
 
-	if (encryption_params.type == HLS_ENC_SAMPLE_AES_CENC)
+	if (encryption_params.type == HLS_ENC_SAMPLE_AES_CTR)
 	{
 		ngx_log_error(NGX_LOG_ERR, submodule_context->request_context.log, 0,
 			"ngx_http_vod_hls_init_ts_frame_processor: sample aes cenc not supported with mpeg ts container");
@@ -716,7 +716,7 @@ ngx_http_vod_hls_handle_mp4_init_segment(
 		}
 		break;
 
-	case HLS_ENC_SAMPLE_AES_CENC:
+	case HLS_ENC_SAMPLE_AES_CTR:
 		drm_info = (drm_info_t*)submodule_context->media_set.sequences[0].drm_info;
 
 		rc = mp4_init_segment_get_encrypted_stsd_writers(
@@ -854,7 +854,7 @@ ngx_http_vod_hls_init_fmp4_frame_processor(
 	if (submodule_context->media_set.total_track_count > 1)
 	{
 #if (NGX_HAVE_OPENSSL_EVP)
-		if (encryption_params.type == HLS_ENC_SAMPLE_AES_CENC)
+		if (encryption_params.type == HLS_ENC_SAMPLE_AES_CTR)
 		{
 			ngx_log_error(NGX_LOG_ERR, submodule_context->request_context.log, 0,
 				"ngx_http_vod_hls_init_fmp4_frame_processor: multiple streams not supported for sample aes cenc");
@@ -887,7 +887,7 @@ ngx_http_vod_hls_init_fmp4_frame_processor(
 	else
 	{
 #if (NGX_HAVE_OPENSSL_EVP)
-		if (encryption_params.type == HLS_ENC_SAMPLE_AES_CENC)
+		if (encryption_params.type == HLS_ENC_SAMPLE_AES_CTR)
 		{
 			drm_writer = *segment_writer;		// must not change segment_writer, otherwise the header will be encrypted
 
@@ -1179,7 +1179,7 @@ ngx_http_vod_hls_merge_loc_conf(
 			"\"vod_hls_version\" must be at least 5 when \"vod_hls_encryption_method\" is sample-aes");
 	}
 
-	if (conf->encryption_method == HLS_ENC_SAMPLE_AES_CENC && conf->m3u8_config.m3u8_version < 6)
+	if (conf->encryption_method == HLS_ENC_SAMPLE_AES_CTR && conf->m3u8_config.m3u8_version < 6)
 	{
 		ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
 			"\"vod_hls_version\" must be at least 6 when \"vod_hls_encryption_method\" is sample-aes-cenc");
@@ -1232,7 +1232,7 @@ ngx_http_vod_hls_parse_uri_file_name(
 			*request = &hls_mp4_segment_request_cbcs;
 			break;
 
-		case HLS_ENC_SAMPLE_AES_CENC:
+		case HLS_ENC_SAMPLE_AES_CTR:
 			*request = &hls_mp4_segment_request_cenc;
 			break;
 

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -64,6 +64,7 @@ ngx_conf_enum_t  hls_encryption_methods[] = {
 	{ ngx_string("aes-128"), HLS_ENC_AES_128 },
 	{ ngx_string("sample-aes"), HLS_ENC_SAMPLE_AES },
 	{ ngx_string("sample-aes-ctr"), HLS_ENC_SAMPLE_AES_CTR },
+	{ ngx_string("sample-aes-cenc"), HLS_ENC_SAMPLE_AES_CENC },
 	{ ngx_null_string, 0 }
 };
 
@@ -1171,6 +1172,14 @@ ngx_http_vod_hls_merge_loc_conf(
 		ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
 			"\"vod_drm_enabled\" must be set when \"vod_hls_encryption_method\" is not none");
 		return NGX_CONF_ERROR;
+	}
+
+	if (conf->encryption_method == HLS_ENC_SAMPLE_AES_CENC)
+	{
+		ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+			"\"vod_hls_encryption_method\" sample-aes-cenc is deprecated, use sample-aes-ctr instead");
+
+		conf->encryption_method = HLS_ENC_SAMPLE_AES_CTR;
 	}
 
 	if (conf->encryption_method == HLS_ENC_SAMPLE_AES && conf->m3u8_config.m3u8_version < 5)

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -63,7 +63,7 @@ ngx_conf_enum_t  hls_encryption_methods[] = {
 	{ ngx_string("none"), HLS_ENC_NONE },
 	{ ngx_string("aes-128"), HLS_ENC_AES_128 },
 	{ ngx_string("sample-aes"), HLS_ENC_SAMPLE_AES },
-	{ ngx_string("sample-aes-cenc"), HLS_ENC_SAMPLE_AES_CTR },
+	{ ngx_string("sample-aes-ctr"), HLS_ENC_SAMPLE_AES_CTR },
 	{ ngx_null_string, 0 }
 };
 
@@ -627,7 +627,7 @@ ngx_http_vod_hls_init_ts_frame_processor(
 	if (encryption_params.type == HLS_ENC_SAMPLE_AES_CTR)
 	{
 		ngx_log_error(NGX_LOG_ERR, submodule_context->request_context.log, 0,
-			"ngx_http_vod_hls_init_ts_frame_processor: sample aes cenc not supported with mpeg ts container");
+			"ngx_http_vod_hls_init_ts_frame_processor: sample-aes-ctr not supported with mpeg-ts container");
 		return ngx_http_vod_status_to_ngx_error(submodule_context->r, VOD_BAD_REQUEST);
 	}
 
@@ -857,7 +857,7 @@ ngx_http_vod_hls_init_fmp4_frame_processor(
 		if (encryption_params.type == HLS_ENC_SAMPLE_AES_CTR)
 		{
 			ngx_log_error(NGX_LOG_ERR, submodule_context->request_context.log, 0,
-				"ngx_http_vod_hls_init_fmp4_frame_processor: multiple streams not supported for sample aes cenc");
+				"ngx_http_vod_hls_init_fmp4_frame_processor: multiple streams not supported for sample-aes-ctr");
 			return ngx_http_vod_status_to_ngx_error(submodule_context->r, VOD_BAD_REQUEST);
 		}
 #endif // NGX_HAVE_OPENSSL_EVP
@@ -1182,7 +1182,7 @@ ngx_http_vod_hls_merge_loc_conf(
 	if (conf->encryption_method == HLS_ENC_SAMPLE_AES_CTR && conf->m3u8_config.m3u8_version < 6)
 	{
 		ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
-			"\"vod_hls_version\" must be at least 6 when \"vod_hls_encryption_method\" is sample-aes-cenc");
+			"\"vod_hls_version\" must be at least 6 when \"vod_hls_encryption_method\" is sample-aes-ctr");
 	}
 
 	if (conf->m3u8_config.container_format == HLS_CONTAINER_FMP4 && conf->m3u8_config.m3u8_version < 6)

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -10,6 +10,7 @@
 #include "vod/udrm.h"
 
 #if (NGX_HAVE_OPENSSL_EVP)
+#include "vod/mp4/mp4_pssh.h"
 #include "vod/dash/edash_packager.h"
 #include "vod/mp4/mp4_cbcs_encrypt.h"
 #include "vod/hls/aes_cbc_encrypt.h"
@@ -685,11 +686,13 @@ ngx_http_vod_hls_handle_mp4_init_segment(
 	ngx_str_t* content_type)
 {
 	atom_writer_t* stsd_atom_writers = NULL;
+	atom_writer_t* pssh_atom_writer = NULL;
 	vod_status_t rc;
 
 #if (NGX_HAVE_OPENSSL_EVP)
 	aes_cbc_encrypt_context_t* encrypted_write_context;
 	hls_encryption_params_t encryption_params;
+	atom_writer_t pssh_atom_writer_temp;
 	drm_info_t* drm_info;
 
 	rc = ngx_http_vod_hls_init_encryption_params(&encryption_params, submodule_context, HLS_CONTAINER_FMP4);
@@ -709,17 +712,12 @@ ngx_http_vod_hls_handle_mp4_init_segment(
 			NULL,
 			encryption_params.iv,
 			&stsd_atom_writers);
-		if (rc != VOD_OK)
-		{
-			ngx_log_debug1(NGX_LOG_DEBUG_HTTP, submodule_context->request_context.log, 0,
-				"ngx_http_vod_hls_handle_mp4_init_segment: mp4_init_segment_get_encrypted_stsd_writers failed %i (1)", rc);
-			return ngx_http_vod_status_to_ngx_error(submodule_context->r, rc);
-		}
 		break;
 
 	case HLS_ENC_SAMPLE_AES_CTR:
 		drm_info = (drm_info_t*)submodule_context->media_set.sequences[0].drm_info;
 
+		// NOTE: similar to DASH, but clear lead is always disabled.
 		rc = mp4_init_segment_get_encrypted_stsd_writers(
 			&submodule_context->request_context,
 			&submodule_context->media_set,
@@ -728,15 +726,19 @@ ngx_http_vod_hls_handle_mp4_init_segment(
 			drm_info->key_id,
 			NULL,
 			&stsd_atom_writers);
-		if (rc != VOD_OK)
-		{
-			ngx_log_debug1(NGX_LOG_DEBUG_HTTP, submodule_context->request_context.log, 0,
-				"ngx_http_vod_hls_handle_mp4_init_segment: mp4_init_segment_get_encrypted_stsd_writers failed %i (2)", rc);
-			return ngx_http_vod_status_to_ngx_error(submodule_context->r, rc);
-		}
+
+		pssh_atom_writer = &pssh_atom_writer_temp;
+		mp4_pssh_init_atom_writer(drm_info, pssh_atom_writer);
 		break;
 
 	default:;
+	}
+
+	if (rc != VOD_OK)
+	{
+		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, submodule_context->request_context.log, 0,
+			"ngx_http_vod_hls_handle_mp4_init_segment: mp4_init_segment_get_encrypted_stsd_writers failed %i", rc);
+		return ngx_http_vod_status_to_ngx_error(submodule_context->r, rc);
 	}
 #endif // NGX_HAVE_OPENSSL_EVP
 
@@ -744,7 +746,7 @@ ngx_http_vod_hls_handle_mp4_init_segment(
 		&submodule_context->request_context,
 		&submodule_context->media_set,
 		ngx_http_vod_submodule_size_only(submodule_context),
-		NULL,
+		pssh_atom_writer,
 		stsd_atom_writers,
 		response);
 	if (rc != VOD_OK)

--- a/sample/nginx.conf
+++ b/sample/nginx.conf
@@ -139,7 +139,7 @@ http {
 			vod_hls_version 6;
 			vod_drm_enabled on;
 			vod_hls_encryption_key_format 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed';
-			vod_hls_encryption_method sample-aes-cenc;
+			vod_hls_encryption_method sample-aes-ctr;
 			add_header Cache-Control $cache_control_directives always;
 			include cors.conf;
 		}

--- a/sample/nginx.conf
+++ b/sample/nginx.conf
@@ -112,7 +112,6 @@ http {
 
 		vod_hls_container_format auto;
 		vod_hls_force_unmuxed_segments on;
-		vod_hls_encryption_key_format_versions '1';
 		vod_hls_absolute_index_urls off;
 		vod_hls_absolute_master_urls off;
 		vod_hls_master_file_name_prefix '';
@@ -129,6 +128,7 @@ http {
 			vod_drm_enabled on;
 			vod_hls_encryption_key_uri 'skd://$vod_set_id';
 			vod_hls_encryption_key_format 'com.apple.streamingkeydelivery';
+			vod_hls_encryption_key_format_versions '1';
 			vod_hls_encryption_method sample-aes;
 			add_header Cache-Control $cache_control_directives always;
 			include cors.conf;
@@ -138,7 +138,6 @@ http {
 			vod hls;
 			vod_hls_version 6;
 			vod_drm_enabled on;
-			vod_hls_encryption_key_format 'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed';
 			vod_hls_encryption_method sample-aes-ctr;
 			add_header Cache-Control $cache_control_directives always;
 			include cors.conf;

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -398,22 +398,23 @@ dash_packager_get_track_spec(
 	media_track_t* track)
 {
 	u_char* p = result->data;
-	u_char media_type_letter[] = { 'v', 'a' };		// must match MEDIA_TYPE_xxx in order
+	const u_char media_type_letter[] = { 'v', 'a' }; // must match MEDIA_TYPE_* order
 
 	if (media_set->has_multi_sequences && sequence->index != INVALID_SEQUENCE_INDEX)
 	{
 		if (sequence->id.len != 0 && sequence->id.len < VOD_INT32_LEN)
 		{
-			p = vod_sprintf(p, "s%V-", &sequence->id);
+			p = vod_sprintf(p, "s%V", &sequence->id);
 		}
 		else
 		{
-			p = vod_sprintf(p, "f%uD-", sequence->index + 1);
+			p = vod_sprintf(p, "f%uD", sequence->index + 1);
 		}
 	}
 
 	if (track->media_info.media_type <= MEDIA_TYPE_AUDIO)
 	{
+		*p++ = '-';
 		*p++ = media_type_letter[track->media_info.media_type];
 		p = vod_sprintf(p, "%uD-x3", track->index + 1); // TODO: remove -xN in the future
 	}

--- a/vod/dash/edash_packager.h
+++ b/vod/dash/edash_packager.h
@@ -36,8 +36,4 @@ vod_status_t edash_packager_get_fragment_writer(
 	vod_str_t* fragment_header,
 	size_t* total_fragment_size);
 
-u_char* edash_packager_write_pssh(
-	u_char* p,
-	drm_system_info_t* cur_info);
-
 #endif //__EDASH_PACKAGER_H__

--- a/vod/dash/edash_packager.h
+++ b/vod/dash/edash_packager.h
@@ -5,10 +5,6 @@
 #include "dash_packager.h"
 #include "../udrm.h"
 
-// constants
-#define EDASH_INIT_MP4_HAS_CLEAR_LEAD	(0x01)
-#define EDASH_INIT_MP4_WRITE_PSSH		(0x02)
-
 // functions
 vod_status_t edash_packager_build_mpd(
 	request_context_t* request_context,
@@ -16,13 +12,6 @@ vod_status_t edash_packager_build_mpd(
 	vod_str_t* base_url,
 	media_set_t* media_set,
 	bool_t drm_single_key,
-	vod_str_t* result);
-
-vod_status_t edash_packager_build_init_mp4(
-	request_context_t* request_context,
-	media_set_t* media_set,
-	uint32_t flags,
-	bool_t size_only,
 	vod_str_t* result);
 
 vod_status_t edash_packager_get_fragment_writer(

--- a/vod/hls/hls_encryption.h
+++ b/vod/hls/hls_encryption.h
@@ -10,7 +10,7 @@ typedef enum {
 	HLS_ENC_NONE,
 	HLS_ENC_AES_128,
 	HLS_ENC_SAMPLE_AES,
-	HLS_ENC_SAMPLE_AES_CENC,
+	HLS_ENC_SAMPLE_AES_CTR,
 } hls_encryption_type_t;
 
 typedef struct {

--- a/vod/hls/hls_encryption.h
+++ b/vod/hls/hls_encryption.h
@@ -11,6 +11,7 @@ typedef enum {
 	HLS_ENC_AES_128,
 	HLS_ENC_SAMPLE_AES,
 	HLS_ENC_SAMPLE_AES_CTR,
+	HLS_ENC_SAMPLE_AES_CENC, // TODO: remove in next major version
 } hls_encryption_type_t;
 
 typedef struct {

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -501,7 +501,7 @@ m3u8_builder_build_index_playlist(
 			result_size += encryption_params->key_uri.len;
 		}
 #if (NGX_HAVE_OPENSSL_EVP)
-		else if (encryption_params->type == HLS_ENC_SAMPLE_AES_CENC)
+		else if (encryption_params->type == HLS_ENC_SAMPLE_AES_CTR)
 		{
 			rc = m3u8_builder_write_psshs(
 				request_context,
@@ -613,7 +613,7 @@ m3u8_builder_build_index_playlist(
 			p = vod_sprintf(p, m3u8_key, m3u8_key_sample_aes);
 			break;
 
-		case HLS_ENC_SAMPLE_AES_CENC:
+		case HLS_ENC_SAMPLE_AES_CTR:
 			p = vod_sprintf(p, m3u8_key, m3u8_key_sample_aes_ctr);
 			break;
 
@@ -628,7 +628,7 @@ m3u8_builder_build_index_playlist(
 			p = vod_copy(p, encryption_params->key_uri.data, encryption_params->key_uri.len);
 		}
 #if (NGX_HAVE_OPENSSL_EVP)
-		else if (encryption_params->type == HLS_ENC_SAMPLE_AES_CENC)
+		else if (encryption_params->type == HLS_ENC_SAMPLE_AES_CTR)
 		{
 			base64.data = vod_copy(p, m3u8_key_uri_sample_aes_ctr_prefix, sizeof(m3u8_key_uri_sample_aes_ctr_prefix) - 1);
 			vod_encode_base64(&base64, &psshs);
@@ -1347,7 +1347,7 @@ m3u8_builder_build_master_playlist(
 
 	// get the adaptations sets
 	flags = ADAPTATION_SETS_FLAG_SINGLE_LANG_TRACK | ADAPTATION_SETS_FLAG_MULTI_AUDIO_CODEC;
-	if (!conf->force_unmuxed_segments && encryption_method != HLS_ENC_SAMPLE_AES_CENC)
+	if (!conf->force_unmuxed_segments && encryption_method != HLS_ENC_SAMPLE_AES_CTR)
 	{
 		flags |= ADAPTATION_SETS_FLAG_MUXED;
 	}

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -399,11 +399,11 @@ m3u8_builder_build_index_playlist(
 	segment_durations_t segment_durations;
 	segment_duration_item_t* cur_item;
 	segment_duration_item_t* last_item;
-	hls_encryption_type_t encryption_type;
+	hls_encryption_type_t encryption_type = encryption_params->type;
 	segmenter_conf_t* segmenter_conf = media_set->segmenter_conf;
 	vod_str_t name_suffix;
 	vod_str_t extinf;
-	vod_str_t* suffix;
+	vod_str_t* suffix = &m3u8_ts_suffix;
 	uint32_t conf_max_segment_duration;
 	uint64_t max_segment_duration;
 	uint64_t duration_millis;
@@ -424,13 +424,7 @@ m3u8_builder_build_index_playlist(
 	// build the required tracks string
 	if (media_set->track_count[MEDIA_TYPE_VIDEO] != 0 || media_set->track_count[MEDIA_TYPE_AUDIO] != 0)
 	{
-		encryption_type = encryption_params->type;
-
-		if (container_format == HLS_CONTAINER_MPEGTS)
-		{
-			suffix = &m3u8_ts_suffix;
-		}
-		else
+		if (container_format == HLS_CONTAINER_FMP4)
 		{
 			suffix = &m3u8_m4s_suffix;
 		}
@@ -1333,7 +1327,7 @@ m3u8_builder_build_master_playlist(
 	media_track_t* audio_codec_tracks[VOD_CODEC_ID_SUBTITLE - VOD_CODEC_ID_AUDIO];
 	media_track_t* cur_track;
 	vod_status_t rc;
-	uint32_t variant_set_count;
+	uint32_t variant_set_count = 1;
 	uint32_t variant_set_size;
 	uint32_t muxed_tracks;
 	uint32_t flags;
@@ -1408,10 +1402,6 @@ m3u8_builder_build_master_playlist(
 		variant_set_count = m3u8_builder_get_audio_codec_count(
 			&adaptation_sets,
 			audio_codec_tracks);
-	}
-	else
-	{
-		variant_set_count = 1;
 	}
 
 	if (adaptation_sets.count[ADAPTATION_TYPE_SUBTITLE] > 0)

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -178,11 +178,9 @@ m3u8_builder_build_tracks_spec(
 	media_track_t** tracks;
 	media_track_t* cur_track;
 	u_char* p;
-	size_t result_size;
-
-	// get the result size
-	result_size = suffix->len +
+	size_t result_size = suffix->len + sizeof("-x") - 1 + VOD_INT32_LEN +
 		(sizeof("-v") - 1 + VOD_INT32_LEN) * media_set->total_track_count;
+
 	if (media_set->has_multi_sequences)
 	{
 		result_size += (sizeof("-f") - 1 + VOD_INT32_LEN) * media_set->total_track_count;
@@ -214,6 +212,12 @@ m3u8_builder_build_tracks_spec(
 		tracks,
 		media_set->total_track_count,
 		media_set->has_multi_sequences);
+
+	// only for audio/video MP4 fragments
+	if (suffix == &m3u8_m4s_suffix)
+	{
+		p = vod_copy(p, "-x3", sizeof("-x3") - 1); // TODO: remove -xN in the future
+	}
 
 	p = vod_copy(p, suffix->data, suffix->len);
 

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -486,7 +486,7 @@ m3u8_builder_build_index_playlist(
 	u_char* p;
 
 #if (NGX_HAVE_OPENSSL_EVP)
-	size_t max_pssh_size = 0;
+	size_t max_pssh_size = 1;
 	u_char* temp_buffer;
 #endif // NGX_HAVE_OPENSSL_EVP
 
@@ -589,14 +589,6 @@ m3u8_builder_build_index_playlist(
 	else if (encryption_type == HLS_ENC_SAMPLE_AES_CTR)
 	{
 		result_size += m3u8_builder_get_keys_size(media_set->sequences[0].drm_info, &max_pssh_size);
-
-		temp_buffer = vod_alloc(request_context->pool, max_pssh_size);
-		if (temp_buffer == NULL)
-		{
-			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
-				"m3u8_builder_build_index_playlist: vod_alloc failed");
-			return VOD_ALLOC_FAILED;
-		}
 	}
 #endif // NGX_HAVE_OPENSSL_EVP
 
@@ -712,6 +704,14 @@ m3u8_builder_build_index_playlist(
 #if (NGX_HAVE_OPENSSL_EVP)
 	else if (encryption_type == HLS_ENC_SAMPLE_AES_CTR)
 	{
+		temp_buffer = vod_alloc(request_context->pool, max_pssh_size);
+		if (temp_buffer == NULL)
+		{
+			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+				"m3u8_builder_build_index_playlist: vod_alloc failed");
+			return VOD_ALLOC_FAILED;
+		}
+
 		p = m3u8_builder_write_keys(p, media_set->sequences[0].drm_info, temp_buffer);
 	}
 #endif // NGX_HAVE_OPENSSL_EVP

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -55,7 +55,7 @@ static const char m3u8_iframe_stream_inf[] = "#EXT-X-I-FRAME-STREAM-INF:BANDWIDT
 static const char m3u8_key[] = "#EXT-X-KEY:METHOD=%s";
 static const u_char m3u8_key_aes_128[] = "AES-128";
 static const u_char m3u8_key_sample_aes[] = "SAMPLE-AES";
-static const u_char m3u8_key_sample_aes_cenc[] = "SAMPLE-AES-CTR";
+static const u_char m3u8_key_sample_aes_ctr[] = "SAMPLE-AES-CTR";
 static const u_char m3u8_key_uri[] = ",URI=\"";
 static const u_char m3u8_key_iv[] = ",IV=0x";
 static const char m3u8_key_keyformat[] = ",KEYFORMAT=\"%V\"";
@@ -63,7 +63,7 @@ static const char m3u8_key_keyformatversions[] = ",KEYFORMATVERSIONS=\"%V\"";
 static const u_char m3u8_key_extension[] = ".key";
 
 #if (NGX_HAVE_OPENSSL_EVP)
-static const u_char m3u8_key_uri_sample_aes_cenc_prefix[] = "data:text/plain;base64,";
+static const u_char m3u8_key_uri_sample_aes_ctr_prefix[] = "data:text/plain;base64,";
 #endif // NGX_HAVE_OPENSSL_EVP
 
 static vod_str_t m3u8_ts_suffix = vod_string(".ts\n");
@@ -492,7 +492,7 @@ m3u8_builder_build_index_playlist(
 	{
 		result_size +=
 			sizeof(m3u8_key) - 1 +
-			sizeof(m3u8_key_sample_aes_cenc) - 1 +
+			sizeof(m3u8_key_sample_aes_ctr) - 1 +
 			sizeof(m3u8_key_uri) - 1 +
 			2;			// '"', '\n'
 
@@ -512,7 +512,7 @@ m3u8_builder_build_index_playlist(
 				return rc;
 			}
 
-			result_size += sizeof(m3u8_key_uri_sample_aes_cenc_prefix) +
+			result_size += sizeof(m3u8_key_uri_sample_aes_ctr_prefix) +
 				vod_base64_encoded_length(psshs.len);
 		}
 #endif // NGX_HAVE_OPENSSL_EVP
@@ -614,7 +614,7 @@ m3u8_builder_build_index_playlist(
 			break;
 
 		case HLS_ENC_SAMPLE_AES_CENC:
-			p = vod_sprintf(p, m3u8_key, m3u8_key_sample_aes_cenc);
+			p = vod_sprintf(p, m3u8_key, m3u8_key_sample_aes_ctr);
 			break;
 
 		default:
@@ -630,7 +630,7 @@ m3u8_builder_build_index_playlist(
 #if (NGX_HAVE_OPENSSL_EVP)
 		else if (encryption_params->type == HLS_ENC_SAMPLE_AES_CENC)
 		{
-			base64.data = vod_copy(p, m3u8_key_uri_sample_aes_cenc_prefix, sizeof(m3u8_key_uri_sample_aes_cenc_prefix) - 1);
+			base64.data = vod_copy(p, m3u8_key_uri_sample_aes_ctr_prefix, sizeof(m3u8_key_uri_sample_aes_ctr_prefix) - 1);
 			vod_encode_base64(&base64, &psshs);
 			p = base64.data + base64.len;
 		}

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -3,8 +3,7 @@
 #include "../mp4/mp4_defs.h"
 
 #if (NGX_HAVE_OPENSSL_EVP)
-#include "../dash/edash_packager.h"
-#include "../mp4/mp4_defs.h"
+#include "../mp4/mp4_pssh.h"
 #endif // NGX_HAVE_OPENSSL_EVP
 
 // constants
@@ -369,7 +368,7 @@ m3u8_builder_write_psshs(
 
 	for (cur_info = drm_info->pssh_array.first; cur_info < drm_info->pssh_array.last; cur_info++)
 	{
-		p = edash_packager_write_pssh(p, cur_info);
+		p = mp4_pssh_write_box(p, cur_info);
 	}
 
 	result->len = p - result->data;

--- a/vod/manifest_utils.c
+++ b/vod/manifest_utils.c
@@ -360,7 +360,7 @@ manifest_utils_append_tracks_spec(
 	media_track_t** cur_track_ptr;
 	media_track_t* cur_track;
 	uint32_t last_sequence_index;
-	u_char media_type_letter[] = { 'v', 'a' };		// must match MEDIA_TYPE_xxx in order
+	const u_char media_type_letter[] = { 'v', 'a' }; // must match MEDIA_TYPE_* order
 
 	last_sequence_index = INVALID_SEQUENCE_INDEX;
 	for (cur_track_ptr = tracks; cur_track_ptr < last_track_ptr; cur_track_ptr++)
@@ -375,6 +375,7 @@ manifest_utils_append_tracks_spec(
 		{
 			cur_sequence = cur_track->file_info.source->sequence;
 
+			// muxed audio/video tracks have the same sequence index
 			if (cur_sequence->index != last_sequence_index)
 			{
 				last_sequence_index = cur_sequence->index;

--- a/vod/mp4/mp4_pssh.c
+++ b/vod/mp4/mp4_pssh.c
@@ -1,0 +1,63 @@
+#include "mp4_defs.h"
+#include "mp4_pssh.h"
+#include "mp4_write_stream.h"
+#include "../udrm.h"
+
+// constants
+const u_char common_system_id[] = {
+	0x10, 0x77, 0xef, 0xec, 0xc0, 0xb2, 0x4d, 0x02,
+	0xac, 0xe3, 0x3c, 0x1e, 0x52, 0xe2, 0xfb, 0x4b
+};
+
+const u_char playready_system_id[] = {
+	0x9a, 0x04, 0xf0, 0x79, 0x98, 0x40, 0x42, 0x86,
+	0xab, 0x92, 0xe6, 0x5b, 0xe0, 0x88, 0x5f, 0x95
+};
+
+u_char*
+mp4_pssh_write_box(u_char* p, drm_system_info_t* info)
+{
+	bool_t is_pssh_v1 = mp4_pssh_is_common(info); // W3C common PSSH box follows `v1` format
+	size_t pssh_atom_size;
+
+	pssh_atom_size = ATOM_HEADER_SIZE + sizeof(pssh_atom_t) + info->data.len;
+	if (is_pssh_v1)
+	{
+		pssh_atom_size -= sizeof(uint32_t);
+	}
+	write_atom_header(p, pssh_atom_size, 'p', 's', 's', 'h');
+
+	if (is_pssh_v1)
+	{
+		write_be32(p, 0x01000000); // version + flags
+	}
+	else
+	{
+		write_be32(p, 0); // version + flags
+	}
+
+	p = vod_copy(p, info->system_id, DRM_SYSTEM_ID_SIZE); // system ID
+
+	if (!is_pssh_v1)
+	{
+		write_be32(p, info->data.len); // data size
+	}
+
+	p = vod_copy(p, info->data.data, info->data.len);
+
+	return p;
+}
+
+u_char*
+mp4_pssh_write_boxes(void* context, u_char* p)
+{
+	drm_system_info_array_t* pssh_array = (drm_system_info_array_t*)context;
+	drm_system_info_t* info;
+
+	for (info = pssh_array->first; info < pssh_array->last; info++)
+	{
+		p = mp4_pssh_write_box(p, info);
+	}
+
+	return p;
+}

--- a/vod/mp4/mp4_pssh.h
+++ b/vod/mp4/mp4_pssh.h
@@ -1,0 +1,22 @@
+#ifndef __MP4_PSSH_H__
+#define __MP4_PSSH_H__
+
+// includes
+#include "../udrm.h"
+
+// macros
+#define mp4_pssh_is_common(info) \
+	(vod_memcmp((info)->system_id, common_system_id, DRM_SYSTEM_ID_SIZE) == 0)
+
+#define mp4_pssh_is_playready(info) \
+	(vod_memcmp((info)->system_id, playready_system_id, DRM_SYSTEM_ID_SIZE) == 0)
+
+// functions
+u_char* mp4_pssh_write_box(u_char* p, drm_system_info_t* info);
+u_char* mp4_pssh_write_boxes(void* context, u_char* p);
+
+// globals
+extern const u_char common_system_id[];
+extern const u_char playready_system_id[];
+
+#endif // __MP4_PSSH_H__

--- a/vod/mp4/mp4_pssh.h
+++ b/vod/mp4/mp4_pssh.h
@@ -2,6 +2,7 @@
 #define __MP4_PSSH_H__
 
 // includes
+#include "mp4_init_segment.h"
 #include "../udrm.h"
 
 // macros
@@ -14,6 +15,7 @@
 // functions
 u_char* mp4_pssh_write_box(u_char* p, drm_system_info_t* info);
 u_char* mp4_pssh_write_boxes(void* context, u_char* p);
+void mp4_pssh_init_atom_writer(drm_info_t* drm_info, atom_writer_t* atom_writer);
 
 // globals
 extern const u_char common_system_id[];


### PR DESCRIPTION
Fixes the content protection signaling for `SAMPLE-AES-CTR`, ensuring PlayReady, Widevine, and PSSH v0-compatible systems are correctly represented in the manifest.
Additionally, write the PSSH boxes to MP4 media initialization and updates the MP4 major brand from `isom` to `iso5`.

The `sample-aes-cenc` encryption method is now deprecated in favor of `sample-aes-ctr`.

> AV1 is not yet compatible with this encryption method.

More at [using content protection systems with HLS](https://developer.apple.com/documentation/http-live-streaming/using-content-protection-systems-with-hls).