### PR TITLE
Fix `vod_dash_fragment_file_name_prefix` default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1683,7 +1683,7 @@ The name of the MP4 initialization file (an `.mp4` extension is implied).
 #### vod_dash_fragment_file_name_prefix
 
 - **syntax**: `vod_dash_fragment_file_name_prefix :name`
-- **default**: `frag`
+- **default**: `fragment`
 - **context**: `http`, `server`, `location`
 
 The name of the fragment files (an `.m4s` extension is implied).


### PR DESCRIPTION
https://github.com/diogoazevedos/nginx-vod-module/blob/f8c165908f30475953187c245e889b45101157db/ngx_http_vod_dash.c#L562

The default value of `vod_dash_fragment_file_name_prefix` is `fragment`, not `frag`.