### PR TITLE
Remove `libxml2` deprecation error

### DIFF
--- a/vod/subtitle/dfxp_format.c
+++ b/vod/subtitle/dfxp_format.c
@@ -438,9 +438,7 @@ dfxp_parse(
 	ctxt->vctxt.error = dfxp_xml_schema_error;
 	ctxt->sax->_private = request_context;
 
-	if (xmlParseDocument(ctxt) != 0 ||
-		ctxt->myDoc == NULL ||
-		(!ctxt->wellFormed && !ctxt->recovery))
+	if (xmlParseDocument(ctxt) != 0 || ctxt->myDoc == NULL || !ctxt->wellFormed)
 	{
 		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
 			"dfxp_parse: xml parsing failed");


### PR DESCRIPTION
Remove usage of the deprecated `recovery` attribute from `libxml2`, which was introduced in `v2.14.0` via https://github.com/GNOME/libxml2/commit/712a31abe458eed75f0e2a442b35af58cf7091ca.
