### PR TITLE
Add HLS session key support

### DIFF
--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -88,9 +88,14 @@ ngx_http_vod_hls_get_container_format(
 		return conf->m3u8_config.container_format;
 	}
 
+	if (conf->encryption_method == HLS_ENC_SAMPLE_AES_CTR)
+	{
+		return HLS_CONTAINER_FMP4;
+	}
+
 	track = media_set->filtered_tracks;
-	if ((track->media_info.media_type == MEDIA_TYPE_VIDEO && track->media_info.codec_id != VOD_CODEC_ID_AVC) ||
-		conf->encryption_method == HLS_ENC_SAMPLE_AES_CTR)
+	if (track->media_info.media_type == MEDIA_TYPE_VIDEO &&
+		track->media_info.codec_id != VOD_CODEC_ID_AVC)
 	{
 		return HLS_CONTAINER_FMP4;
 	}

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -354,7 +354,7 @@ m3u8_builder_build_iframe_playlist(
 
 #if (NGX_HAVE_OPENSSL_EVP)
 static size_t
-m3u8_builder_get_keys_size(drm_info_t* drm_info, size_t* max_pssh_size)
+m3u8_builder_get_keys_size(const char* key_tag, drm_info_t* drm_info, size_t* max_pssh_size)
 {
 	drm_system_info_t* cur_info;
 	size_t result = 0;
@@ -363,7 +363,7 @@ m3u8_builder_get_keys_size(drm_info_t* drm_info, size_t* max_pssh_size)
 	for (cur_info = drm_info->pssh_array.first; cur_info < drm_info->pssh_array.last; cur_info++)
 	{
 		result +=
-			sizeof(m3u8_key) - 1 +
+			sizeof(key_tag) - 1 +
 			sizeof(m3u8_key_sample_aes_ctr) - 1 +
 			sizeof(m3u8_key_uri) - 1 +
 			sizeof(m3u8_key_keyformat) - 1 +
@@ -395,7 +395,7 @@ m3u8_builder_get_keys_size(drm_info_t* drm_info, size_t* max_pssh_size)
 }
 
 static u_char*
-m3u8_builder_write_keys(u_char* p, drm_info_t* drm_info, u_char* temp_buffer)
+m3u8_builder_write_keys(u_char* p, const char* key_tag, drm_info_t* drm_info, u_char* temp_buffer)
 {
 	drm_system_info_t* cur_info;
 	vod_str_t pssh;
@@ -406,7 +406,7 @@ m3u8_builder_write_keys(u_char* p, drm_info_t* drm_info, u_char* temp_buffer)
 	{
 		is_playready = mp4_pssh_is_playready(cur_info);
 
-		p = vod_sprintf(p, m3u8_key, m3u8_key_sample_aes_ctr);
+		p = vod_sprintf(p, key_tag, m3u8_key_sample_aes_ctr);
 
 		p = vod_copy(p, m3u8_key_uri, sizeof(m3u8_key_uri) - 1);
 		if (is_playready)
@@ -588,7 +588,8 @@ m3u8_builder_build_index_playlist(
 #if (NGX_HAVE_OPENSSL_EVP)
 	else if (encryption_type == HLS_ENC_SAMPLE_AES_CTR)
 	{
-		result_size += m3u8_builder_get_keys_size(media_set->sequences[0].drm_info, &max_pssh_size);
+		result_size +=
+			m3u8_builder_get_keys_size(m3u8_key, media_set->sequences[0].drm_info, &max_pssh_size);
 	}
 #endif // NGX_HAVE_OPENSSL_EVP
 
@@ -712,7 +713,7 @@ m3u8_builder_build_index_playlist(
 			return VOD_ALLOC_FAILED;
 		}
 
-		p = m3u8_builder_write_keys(p, media_set->sequences[0].drm_info, temp_buffer);
+		p = m3u8_builder_write_keys(p, m3u8_key, media_set->sequences[0].drm_info, temp_buffer);
 	}
 #endif // NGX_HAVE_OPENSSL_EVP
 

--- a/vod/hls/m3u8_builder.h
+++ b/vod/hls/m3u8_builder.h
@@ -38,7 +38,7 @@ typedef struct {
 vod_status_t m3u8_builder_build_master_playlist(
 	request_context_t* request_context,
 	m3u8_config_t* conf,
-	vod_uint_t encryption_method,
+	hls_encryption_params_t* encryption_params,
 	vod_str_t* base_url,
 	media_set_t* media_set,
 	vod_str_t* result);


### PR DESCRIPTION
Adds support for the `#EXT-X-SESSION-KEY` tag in HLS playlists, allowing the player to initiate certificate exchanges earlier and reduce playback startup time. **Note** that only a single session key is supported in this implementation.