### PR TITLE
Build against stable and mainline nginx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,14 @@ on:
 
 jobs:
   build:
-    name: Build using ${{ matrix.build-mode }}
+    name: Build for ${{ matrix.nginx-version }} using ${{ matrix.build-mode }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
+        nginx-version:
+          - 1.28.0
+          - 1.29.0
         build-mode:
           - --add-module
           - --add-dynamic-module
@@ -30,7 +33,7 @@ jobs:
         with:
           path: nginx-vod-module
       - run: mkdir nginx
-      - run: curl -s https://nginx.org/download/nginx-1.29.0.tar.gz | tar -xz --strip-components 1 -C nginx
+      - run: curl -s https://nginx.org/download/nginx-${{ matrix.nginx-version }}.tar.gz | tar -xz --strip-components 1 -C nginx
       - working-directory: nginx
         run: |
           ../nginx-vod-module/scripts/build_basic.sh \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: nginx-vod-module
       - run: mkdir nginx
-      - run: curl -s https://nginx.org/download/nginx-1.28.0.tar.gz | tar -xz --strip-components 1 -C nginx
+      - run: curl -s https://nginx.org/download/nginx-1.29.0.tar.gz | tar -xz --strip-components 1 -C nginx
       - working-directory: nginx
         run: |
           ../nginx-vod-module/scripts/build_basic.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1-labs
 
-FROM alpine:3.21.3 AS build
+FROM alpine:3.22.1 AS build
 
 RUN apk --no-cache add \
 		build-base \
@@ -45,7 +45,7 @@ RUN /nginx-vod-module/scripts/build_basic.sh \
 		--with-cc-opt='-O0' \
 	&& make install
 
-FROM alpine:3.21.3
+FROM alpine:3.22.1
 
 LABEL maintainer="Diogo Azevedo <diogoazevedos@gmail.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add \
 		fdk-aac-dev \
 		openssl-dev \
 	&& mkdir /nginx \
-	&& wget -qO- https://nginx.org/download/nginx-1.28.0.tar.gz | tar -xz --strip-components 1 -C /nginx
+	&& wget -qO- https://nginx.org/download/nginx-1.29.0.tar.gz | tar -xz --strip-components 1 -C /nginx
 
 COPY --exclude=sample . /nginx-vod-module
 


### PR DESCRIPTION
NGINX maintains two release branches: **stable** and **mainline**. Modules should support these actively maintained versions.