### PR TITLE
Drop legacy DASH PlayReady signaling

### DIFF
--- a/ngx_http_vod_dash.c
+++ b/ngx_http_vod_dash.c
@@ -542,7 +542,6 @@ ngx_http_vod_dash_create_loc_conf(
 	conf->mpd_config.manifest_format = NGX_CONF_UNSET_UINT;
 	conf->mpd_config.subtitle_format = NGX_CONF_UNSET_UINT;
 	conf->mpd_config.duplicate_bitrate_threshold = NGX_CONF_UNSET_UINT;
-	conf->mpd_config.write_playready_kid = NGX_CONF_UNSET;
 	conf->mpd_config.use_base_url_tag = NGX_CONF_UNSET;
 }
 
@@ -564,7 +563,6 @@ ngx_http_vod_dash_merge_loc_conf(
 	ngx_conf_merge_uint_value(conf->mpd_config.manifest_format, prev->mpd_config.manifest_format, FORMAT_SEGMENT_TIMELINE);
 	ngx_conf_merge_uint_value(conf->mpd_config.subtitle_format, prev->mpd_config.subtitle_format, SUBTITLE_FORMAT_WEBVTT);
 	ngx_conf_merge_uint_value(conf->mpd_config.duplicate_bitrate_threshold, prev->mpd_config.duplicate_bitrate_threshold, 4096);
-	ngx_conf_merge_value(conf->mpd_config.write_playready_kid, prev->mpd_config.write_playready_kid, 0);
 	ngx_conf_merge_value(conf->mpd_config.use_base_url_tag, prev->mpd_config.use_base_url_tag, 0);
 
 	return NGX_CONF_OK;

--- a/ngx_http_vod_dash_commands.h
+++ b/ngx_http_vod_dash_commands.h
@@ -70,13 +70,6 @@
 	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, mpd_config.duplicate_bitrate_threshold),
 	NULL },
 
-	{ ngx_string("vod_dash_write_playready_kid"),
-	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-	ngx_conf_set_flag_slot,
-	NGX_HTTP_LOC_CONF_OFFSET,
-	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, mpd_config.write_playready_kid),
-	NULL },
-
 	{ ngx_string("vod_dash_use_base_url_tag"),
 	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
 	ngx_conf_set_flag_slot,

--- a/vod/dash/dash_packager.h
+++ b/vod/dash/dash_packager.h
@@ -41,7 +41,6 @@ typedef struct {
 	vod_uint_t manifest_format;
 	vod_uint_t subtitle_format;
 	vod_uint_t duplicate_bitrate_threshold;
-	bool_t write_playready_kid;		// TODO: remove
 	bool_t use_base_url_tag;		// TODO: remove - if supported by all devices, always use BaseURL
 } dash_manifest_config_t;
 

--- a/vod/dash/edash_packager.c
+++ b/vod/dash/edash_packager.c
@@ -26,14 +26,10 @@ static const u_char mpd_content_protection_cenc_part4[] =
 	"</cenc:pssh>\n"
 	"      </ContentProtection>\n";
 
-// TODO: remove this - always generate a default_KID for PlayReady
 static const u_char mpd_content_protection_playready_part1[] =
-	"      <ContentProtection xmlns:mspr=\"urn:microsoft:playready\" schemeIdUri=\"urn:uuid:";
-
-static const u_char mpd_content_protection_playready_v2_part1[] =
 	"      <ContentProtection xmlns:cenc=\"urn:mpeg:cenc:2013\" xmlns:mspr=\"urn:microsoft:playready\" schemeIdUri=\"urn:uuid:";
 
-static const u_char mpd_content_protection_playready_v2_part2[] =
+static const u_char mpd_content_protection_playready_part2[] =
 	"\" value=\"2.0\" cenc:default_KID=\"";
 
 static const u_char mpd_content_protection_playready_part3[] =
@@ -44,16 +40,9 @@ static const u_char mpd_content_protection_playready_part4[] =
 	"</mspr:pro>\n"
 	"      </ContentProtection>\n";
 
-// mpd types
-typedef struct {
-	u_char* temp_buffer;
-	bool_t write_playready_kid;
-} write_content_protection_context_t;
-
 static u_char*
-edash_packager_write_content_protection(void* ctx, u_char* p, media_track_t* track)
+edash_packager_write_content_protection(void* temp_buffer, u_char* p, media_track_t* track)
 {
-	write_content_protection_context_t* context = ctx;
 	drm_info_t* drm_info = (drm_info_t*)track->file_info.drm_info;
 	drm_system_info_t* cur_info;
 	vod_str_t base64;
@@ -69,24 +58,14 @@ edash_packager_write_content_protection(void* ctx, u_char* p, media_track_t* tra
 	{
 		if (mp4_pssh_is_playready(cur_info))
 		{
-			if (context->write_playready_kid)
-			{
-				p = vod_copy(p,
-					mpd_content_protection_playready_v2_part1,
-					sizeof(mpd_content_protection_playready_v2_part1) - 1);
-				p = mp4_cenc_encrypt_write_guid(p, cur_info->system_id);
-				p = vod_copy(p,
-					mpd_content_protection_playready_v2_part2,
-					sizeof(mpd_content_protection_playready_v2_part2) - 1);
-				p = mp4_cenc_encrypt_write_guid(p, drm_info->key_id);
-			}
-			else
-			{
-				p = vod_copy(p,
-					mpd_content_protection_playready_part1,
-					sizeof(mpd_content_protection_playready_part1) - 1);
-				p = mp4_cenc_encrypt_write_guid(p, cur_info->system_id);
-			}
+			p = vod_copy(p,
+				mpd_content_protection_playready_part1,
+				sizeof(mpd_content_protection_playready_part1) - 1);
+			p = mp4_cenc_encrypt_write_guid(p, cur_info->system_id);
+			p = vod_copy(p,
+				mpd_content_protection_playready_part2,
+				sizeof(mpd_content_protection_playready_part2) - 1);
+			p = mp4_cenc_encrypt_write_guid(p, drm_info->key_id);
 			p = vod_copy(p,
 				mpd_content_protection_playready_part3,
 				sizeof(mpd_content_protection_playready_part3) - 1);
@@ -113,7 +92,7 @@ edash_packager_write_content_protection(void* ctx, u_char* p, media_track_t* tra
 				mpd_content_protection_cenc_part3,
 				sizeof(mpd_content_protection_cenc_part3) - 1);
 
-			pssh.data = context->temp_buffer;
+			pssh.data = temp_buffer;
 			pssh.len = mp4_pssh_write_box(pssh.data, cur_info) - pssh.data;
 
 			base64.data = p;
@@ -137,7 +116,6 @@ edash_packager_build_mpd(
 	bool_t drm_single_key,
 	vod_str_t* result)
 {
-	write_content_protection_context_t context;
 	dash_manifest_extensions_t extensions;
 	media_sequence_t* cur_sequence;
 	drm_system_info_t* cur_info;
@@ -147,6 +125,7 @@ edash_packager_build_mpd(
 	size_t cur_drm_tags_size;
 	size_t cur_pssh_size;
 	size_t max_pssh_size = 0;
+	u_char* temp_buffer;
 	vod_status_t rc;
 
 	representation_tags_size = 0;
@@ -162,9 +141,9 @@ edash_packager_build_mpd(
 			if (mp4_pssh_is_playready(cur_info))
 			{
 				cur_drm_tags_size +=
-					sizeof(mpd_content_protection_playready_v2_part1) - 1 +
+					sizeof(mpd_content_protection_playready_part1) - 1 +
 					VOD_GUID_LENGTH +
-					sizeof(mpd_content_protection_playready_v2_part2) - 1 +
+					sizeof(mpd_content_protection_playready_part2) - 1 +
 					VOD_GUID_LENGTH +
 					sizeof(mpd_content_protection_playready_part3) - 1 +
 					vod_base64_encoded_length(cur_info->data.len) +
@@ -194,11 +173,10 @@ edash_packager_build_mpd(
 		representation_tags_size += cur_drm_tags_size * cur_sequence->total_track_count;
 	}
 
-	context.write_playready_kid = conf->write_playready_kid;
 	if (max_pssh_size > 0)
 	{
-		context.temp_buffer = vod_alloc(request_context->pool, max_pssh_size);
-		if (context.temp_buffer == NULL)
+		temp_buffer = vod_alloc(request_context->pool, max_pssh_size);
+		if (temp_buffer == NULL)
 		{
 			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
 				"edash_packager_build_mpd: vod_alloc failed");
@@ -208,7 +186,7 @@ edash_packager_build_mpd(
 
 	content_prot_writer.size = representation_tags_size;
 	content_prot_writer.write = edash_packager_write_content_protection;
-	content_prot_writer.context = &context;
+	content_prot_writer.context = temp_buffer;
 
 	if (drm_single_key)
 	{

--- a/vod/dash/edash_packager.c
+++ b/vod/dash/edash_packager.c
@@ -125,7 +125,7 @@ edash_packager_build_mpd(
 	size_t cur_drm_tags_size;
 	size_t cur_pssh_size;
 	size_t max_pssh_size = 0;
-	u_char* temp_buffer;
+	u_char* temp_buffer = NULL;
 	vod_status_t rc;
 
 	representation_tags_size = 0;


### PR DESCRIPTION
As mentioned on #43, removes the non-documented config `vod_dash_write_playready_kid` and make its behavior permanent.