### PR TITLE
Remove deprecated HLS encryption method

### DIFF
--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -65,7 +65,6 @@ ngx_conf_enum_t  hls_encryption_methods[] = {
 	{ ngx_string("aes-128"), HLS_ENC_AES_128 },
 	{ ngx_string("sample-aes"), HLS_ENC_SAMPLE_AES },
 	{ ngx_string("sample-aes-ctr"), HLS_ENC_SAMPLE_AES_CTR },
-	{ ngx_string("sample-aes-cenc"), HLS_ENC_SAMPLE_AES_CENC },
 	{ ngx_null_string, 0 }
 };
 
@@ -1219,14 +1218,6 @@ ngx_http_vod_hls_merge_loc_conf(
 		ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
 			"\"vod_drm_enabled\" must be set when \"vod_hls_encryption_method\" is not none");
 		return NGX_CONF_ERROR;
-	}
-
-	if (conf->encryption_method == HLS_ENC_SAMPLE_AES_CENC)
-	{
-		ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
-			"\"vod_hls_encryption_method\" sample-aes-cenc is deprecated, use sample-aes-ctr instead");
-
-		conf->encryption_method = HLS_ENC_SAMPLE_AES_CTR;
 	}
 
 	if (conf->encryption_method == HLS_ENC_SAMPLE_AES && conf->m3u8_config.m3u8_version < 5)

--- a/vod/hls/hls_encryption.h
+++ b/vod/hls/hls_encryption.h
@@ -10,8 +10,7 @@ typedef enum {
 	HLS_ENC_NONE,
 	HLS_ENC_AES_128,
 	HLS_ENC_SAMPLE_AES,
-	HLS_ENC_SAMPLE_AES_CTR,
-	HLS_ENC_SAMPLE_AES_CENC, // TODO: remove in next major version
+	HLS_ENC_SAMPLE_AES_CTR
 } hls_encryption_type_t;
 
 typedef struct {


### PR DESCRIPTION
Removes the `sample-aes-cenc` encryption method deprecated via #42.