### PR TITLE
Ensure C23 standard compatibility

### DIFF
--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -216,7 +216,7 @@ typedef struct {
 static ngx_int_t ngx_http_vod_run_state_machine(ngx_http_vod_ctx_t *ctx);
 static ngx_int_t ngx_http_vod_send_notification(ngx_http_vod_ctx_t *ctx);
 static ngx_int_t ngx_http_vod_init_process(ngx_cycle_t *cycle);
-static void ngx_http_vod_exit_process();
+static void ngx_http_vod_exit_process(ngx_cycle_t *cycle);
 
 static ngx_int_t ngx_http_vod_init_file_reader_with_fallback(ngx_http_request_t *r, ngx_str_t* path, uint32_t flags, void** context);
 static ngx_int_t ngx_http_vod_init_file_reader(ngx_http_request_t *r, ngx_str_t* path, uint32_t flags, void** context);
@@ -3397,7 +3397,7 @@ ngx_http_vod_init_process(ngx_cycle_t *cycle)
 }
 
 static void
-ngx_http_vod_exit_process()
+ngx_http_vod_exit_process(ngx_cycle_t *cycle)
 {
 #if (VOD_HAVE_ICONV)
 	webvtt_exit_process();


### PR DESCRIPTION
Fixes the following errors when compiling using `-std=c23`:

```
ngx_http_vod_module.c:242:5: error: initialization of 'void (*)(ngx_cycle_t *)' from incompatible pointer type 'void (*)(void)'
  242 |     ngx_http_vod_exit_process,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~

ngx_http_vod_module.c:243:5: error: initialization of 'void (*)(ngx_cycle_t *)' from incompatible pointer type 'void (*)(void)'
  243 |     ngx_http_vod_exit_process,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
```