### PR TITLE
Bump default HLS version to 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1760,7 +1760,7 @@ video stream (using `#EXT-X-MEDIA`).
 #### vod_hls_version
 
 - **syntax**: `vod_hls_version :version`
-- **default**: `4`
+- **default**: `6`
 - **context**: `http`, `server`, `location`
 
 Sets the version of the manifest. See

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -1091,7 +1091,7 @@ ngx_http_vod_hls_merge_loc_conf(
 	}
 	ngx_conf_merge_value(conf->m3u8_config.force_unmuxed_segments, prev->m3u8_config.force_unmuxed_segments, 0);
 	ngx_conf_merge_uint_value(conf->m3u8_config.container_format, prev->m3u8_config.container_format, HLS_CONTAINER_AUTO);
-	ngx_conf_merge_uint_value(conf->m3u8_config.m3u8_version, prev->m3u8_config.m3u8_version, 4);
+	ngx_conf_merge_uint_value(conf->m3u8_config.m3u8_version, prev->m3u8_config.m3u8_version, 6);
 
 	ngx_conf_merge_value(conf->interleave_frames, prev->interleave_frames, 0);
 	ngx_conf_merge_value(conf->align_frames, prev->align_frames, 1);


### PR DESCRIPTION
The minimum HLS version for the CMAF compliance goal is `6`. Most devices from *2016 onwards* support higher versions.