### PR TITLE
Remove unnecessary DASH base url config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1728,16 +1728,6 @@ disabled, the `pssh` boxes are returned only in the manifest.
 The bitrate threshold for removing **identical** bitrates, streams whose bitrate differences are
 less than this value will be considered identical.
 
-#### vod_dash_use_base_url_tag
-
-- **syntax**: `vod_dash_use_base_url_tag on | off`
-- **default**: `off`
-- **context**: `http`, `server`, `location`
-
-When enabled, a `BaseURL` tag will be used to specify the fragments and init segment base URL.
-Otherwise, the `media` and `initialization` attributes under `SegmentTemplate` will contain absolute
-URLs.
-
 ### Configuration directives - HLS
 
 #### vod_hls_encryption_method

--- a/ngx_http_vod_dash.c
+++ b/ngx_http_vod_dash.c
@@ -542,7 +542,6 @@ ngx_http_vod_dash_create_loc_conf(
 	conf->mpd_config.manifest_format = NGX_CONF_UNSET_UINT;
 	conf->mpd_config.subtitle_format = NGX_CONF_UNSET_UINT;
 	conf->mpd_config.duplicate_bitrate_threshold = NGX_CONF_UNSET_UINT;
-	conf->mpd_config.use_base_url_tag = NGX_CONF_UNSET;
 }
 
 static char *
@@ -563,7 +562,6 @@ ngx_http_vod_dash_merge_loc_conf(
 	ngx_conf_merge_uint_value(conf->mpd_config.manifest_format, prev->mpd_config.manifest_format, FORMAT_SEGMENT_TIMELINE);
 	ngx_conf_merge_uint_value(conf->mpd_config.subtitle_format, prev->mpd_config.subtitle_format, SUBTITLE_FORMAT_WEBVTT);
 	ngx_conf_merge_uint_value(conf->mpd_config.duplicate_bitrate_threshold, prev->mpd_config.duplicate_bitrate_threshold, 4096);
-	ngx_conf_merge_value(conf->mpd_config.use_base_url_tag, prev->mpd_config.use_base_url_tag, 0);
 
 	return NGX_CONF_OK;
 }

--- a/ngx_http_vod_dash_commands.h
+++ b/ngx_http_vod_dash_commands.h
@@ -70,11 +70,4 @@
 	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, mpd_config.duplicate_bitrate_threshold),
 	NULL },
 
-	{ ngx_string("vod_dash_use_base_url_tag"),
-	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-	ngx_conf_set_flag_slot,
-	NGX_HTTP_LOC_CONF_OFFSET,
-	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, mpd_config.use_base_url_tag),
-	NULL },
-
 #undef BASE_OFFSET

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -1383,16 +1383,9 @@ dash_packager_build_mpd(
 	// get the base url
 	if (base_url->len != 0)
 	{
-		if (conf->use_base_url_tag)
-		{
-			result_size += sizeof(mpd_baseurl) - 1 + base_url->len;
-			context.base_url.data = NULL;
-			context.base_url.len = 0;
-		}
-		else
-		{
-			context.base_url = *base_url;
-		}
+		result_size += sizeof(mpd_baseurl) - 1 + base_url->len;
+		context.base_url.data = NULL;
+		context.base_url.len = 0;
 	}
 	else
 	{
@@ -1653,7 +1646,7 @@ dash_packager_build_mpd(
 		break;
 	}
 
-	if (conf->use_base_url_tag && base_url->len != 0)
+	if (base_url->len != 0)
 	{
 		p = vod_sprintf(p, mpd_baseurl, base_url);
 	}

--- a/vod/dash/dash_packager.h
+++ b/vod/dash/dash_packager.h
@@ -41,7 +41,6 @@ typedef struct {
 	vod_uint_t manifest_format;
 	vod_uint_t subtitle_format;
 	vod_uint_t duplicate_bitrate_threshold;
-	bool_t use_base_url_tag;		// TODO: remove - if supported by all devices, always use BaseURL
 } dash_manifest_config_t;
 
 typedef struct {


### PR DESCRIPTION
The `BaseURL` is largely compatible with devices released from *2016 onwards*.