### PR TITLE
Fix DASH representation ID for single sequence, again

### DIFF
--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -400,11 +400,11 @@ dash_packager_get_track_spec(
 		{
 			p = vod_sprintf(p, "f%uD", sequence->index + 1);
 		}
+		*p++ = '-';
 	}
 
 	if (track->media_info.media_type <= MEDIA_TYPE_AUDIO)
 	{
-		*p++ = '-';
 		*p++ = media_type_letter[track->media_info.media_type];
 		p = vod_sprintf(p, "%uD", track->index + 1);
 	}


### PR DESCRIPTION
The regression from #21 was unintentionally reintroduced in #42 via c8105decc25f5db2f5b1a2472d4ae19721218f56. Ensures the problem is resolved once and for all.