### PR TITLE
Update nginx to v1.29.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         nginx-version:
           - 1.28.0
-          - 1.29.0
+          - 1.29.1
         build-mode:
           - --add-module
           - --add-dynamic-module

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM alpine:3.22.1 AS build
 
-ARG NGINX_VERSION=1.29.0
+ARG NGINX_VERSION=1.29.1
 
 RUN apk --no-cache add \
 		build-base \


### PR DESCRIPTION
Update NGINX to latest mainline v1.29.1. No impacting changes introduced.