### PR TITLE
Ensure that DASH audio channels are correct

### DIFF
--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -93,11 +93,10 @@ static const char mpd_adaptation_header_subtitle_vtt[] =
 static const char mpd_label[] =
 	"      <Label>%V</Label>\n";
 
-// TODO: value should be the number of channels ?
-static const u_char mpd_audio_channel_config[] =
+static const char mpd_audio_channel_config[] =
 	"      <AudioChannelConfiguration\n"
 	"          schemeIdUri=\"urn:mpeg:dash:23003:3:audio_channel_configuration:2011\"\n"
-	"          value=\"1\"/>\n";
+	"          value=\"%uD\"/>\n";
 
 static const char mpd_audio_channel_config_eac3[] =
 	"      <AudioChannelConfiguration\n"
@@ -914,7 +913,8 @@ dash_packager_write_mpd_period(
 			}
 			else
 			{
-				p = vod_copy(p, mpd_audio_channel_config, sizeof(mpd_audio_channel_config) - 1);
+				p = vod_sprintf(p, mpd_audio_channel_config,
+					(uint32_t)reference_track->media_info.u.audio.channels);
 			}
 			break;
 


### PR DESCRIPTION
Fixes the `@value` of `AudioChannelConfiguration` for the URI `urn:mpeg:dash:23003:3:audio_channel_configuration:2011` by using the correct `ChannelConfiguration` value defined in [ISO/IEC 23091-3:2018](https://www.iso.org/standard/73413.html) instead of hard-coding `1` (as required by [ISO/IEC 23009-1:2022](https://www.iso.org/standard/83314.html) § 5.8.5.4).