### PR TITLE
Switch to 1-based `mfhd.sequence_number`

### DIFF
--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -1897,7 +1897,7 @@ dash_packager_build_fragment_header(
 	write_atom_header(p, moof_atom_size, 'm', 'o', 'o', 'f');
 
 	// moof.mfhd
-	p = mp4_fragment_write_mfhd_atom(p, segment_index);
+	p = mp4_fragment_write_mfhd_atom(p, segment_index + 1);
 
 	// moof.traf
 	write_atom_header(p, traf_atom_size, 't', 'r', 'a', 'f');


### PR DESCRIPTION
Aligns the `mfhd.sequence_number` with the common convention of starting from `1`.
