### PR TITLE
Drop support for FFmpeg below v5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you wish to make use of the following features:
 - Thumbnail capture
 - Playback rate change - 0.5x up to 2x
 
-You will also need to install the [`ffmpeg`](https://ffmpeg.org).
+You will also need to install the [`ffmpeg`](https://ffmpeg.org) v6+.
 
 #### Quick start
 

--- a/vod/filters/audio_decoder.c
+++ b/vod/filters/audio_decoder.c
@@ -7,10 +7,6 @@ static bool_t initialized = FALSE;
 void
 audio_decoder_process_init(vod_log_t* log)
 {
-	#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 18, 100)
-		avcodec_register_all();
-	#endif
-
 	decoder_codec = avcodec_find_decoder(AV_CODEC_ID_AAC);
 	if (decoder_codec == NULL)
 	{
@@ -56,12 +52,7 @@ audio_decoder_init_decoder(
 	decoder->extradata = media_info->extra_data.data;
 	decoder->extradata_size = media_info->extra_data.len;
 
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 23, 100)
 	av_channel_layout_from_mask(&decoder->ch_layout, media_info->u.audio.channel_layout);
-#else
-	decoder->channels = media_info->u.audio.channels;
-	decoder->channel_layout = media_info->u.audio.channel_layout;
-#endif
 
 	decoder->bits_per_coded_sample = media_info->u.audio.bits_per_sample;
 	decoder->sample_rate = media_info->u.audio.sample_rate;

--- a/vod/filters/audio_encoder.c
+++ b/vod/filters/audio_encoder.c
@@ -68,10 +68,6 @@ audio_encoder_process_init(vod_log_t* log)
 {
 	char** name;
 
-	#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 18, 100)
-		avcodec_register_all();
-	#endif
-
 	for (name = aac_encoder_names; ; name++)
 	{
 		if (*name == NULL)
@@ -142,12 +138,7 @@ audio_encoder_init(
 	encoder->time_base.den = params->timescale;
 	encoder->sample_rate = params->sample_rate;
 
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 23, 100)
 	av_channel_layout_from_mask(&encoder->ch_layout, params->channel_layout);
-#else
-	encoder->channels = params->channels;
-	encoder->channel_layout = params->channel_layout;
-#endif
 
 	encoder->bit_rate = params->bitrate;
 	encoder->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;		// make the codec generate the extra data
@@ -353,15 +344,8 @@ audio_encoder_update_media_info(
 	media_info->bitrate = encoder->bit_rate;
 
 	media_info->u.audio.object_type_id = 0x40;		// ffmpeg always writes 0x40 (ff_mp4_obj_type)
-
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 23, 100)
 	media_info->u.audio.channels = encoder->ch_layout.nb_channels;
 	media_info->u.audio.channel_layout = encoder->ch_layout.u.mask;
-#else
-	media_info->u.audio.channels = encoder->channels;
-	media_info->u.audio.channel_layout = encoder->channel_layout;
-#endif
-
 	media_info->u.audio.bits_per_sample = AUDIO_ENCODER_BITS_PER_SAMPLE;
 	media_info->u.audio.packet_size = 0;			// ffmpeg always writes 0 (mov_write_audio_tag)
 	media_info->u.audio.sample_rate = encoder->sample_rate;

--- a/vod/filters/volume_map.c
+++ b/vod/filters/volume_map.c
@@ -55,13 +55,7 @@ volume_map_calc_frame(
 	const float* end;
 	double sum_squares;
 	double sample;
-	int channels;
-
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 23, 100)
-	channels = frame->ch_layout.nb_channels;
-#else
-	channels = frame->channels;
-#endif
+	int channels = frame->ch_layout.nb_channels;
 
 	switch (frame->format)
 	{

--- a/vod/thumb/thumb_grabber.c
+++ b/vod/thumb/thumb_grabber.c
@@ -55,9 +55,7 @@ static codec_id_mapping_t codec_mappings[] = {
 	{ VOD_CODEC_ID_HEVC, AV_CODEC_ID_H265, "h265" },
 	{ VOD_CODEC_ID_VP8, AV_CODEC_ID_VP8, "vp8" },
 	{ VOD_CODEC_ID_VP9, AV_CODEC_ID_VP9, "vp9" },
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 89, 100)
 	{ VOD_CODEC_ID_AV1, AV_CODEC_ID_AV1, "av1" },
-#endif
 };
 
 void
@@ -67,9 +65,6 @@ thumb_grabber_process_init(vod_log_t* log)
 	codec_id_mapping_t* mapping_cur;
 	codec_id_mapping_t* mapping_end;
 
-	#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 18, 100)
-		avcodec_register_all();
-	#endif
 	vod_memzero(decoder_codec, sizeof(decoder_codec));
 
 	encoder_codec = avcodec_find_encoder(AV_CODEC_ID_MJPEG);


### PR DESCRIPTION
As mentioned in #71, FFmpeg compatibility is now limited to the **latest three major versions** to ensure maintainability and alignment with current APIs.
FFmpeg `v5.1` remains supported but not actively tracked.
The recommended minimum version for building and testing is `v6.1+`.