### PR TITLE
Document sequence ID max length constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,8 +550,8 @@ Mandatory fields:
 
 Optional fields:
 
-- `id` - a string that identifies the sequence. The string must **not** contain `-`. The ID can be
-  retrieved by `$vod_sequence_id`.
+- `id` - a string that identifies the sequence. The string must **not** contain `-` and be at most
+  *10 characters* long. The ID can be retrieved via `$vod_sequence_id`.
 - `language` - a 3-letter (ISO-639-2) language code, this field takes priority over any language
   specified on the media file (`mdhd` MP4 atom).
 - `label` - a friendly string that identifies the sequence. If a language is specified, a default


### PR DESCRIPTION
Documents the *10-character* limit for the `id` field in sequence config.