### PR TITLE
Fix incorrect segment reporting for sources with offset

### DIFF
--- a/vod/segmenter.c
+++ b/vod/segmenter.c
@@ -1765,6 +1765,9 @@ segmenter_get_segment_durations_accurate(
 	align_to_key_frames =
 		conf->align_to_key_frames && main_track->media_info.media_type == MEDIA_TYPE_VIDEO;
 
+	segment_start = main_track->first_frame_time_offset;
+	accum_duration = main_track->first_frame_time_offset;
+
 	// bootstrap segments
 	if (conf->bootstrap_segments_count > 0) {
 		segment_limit = rescale_time(conf->bootstrap_segments_end[0], 1000, result->timescale);


### PR DESCRIPTION
Accounts for initial offset in playlist generation, preventing reporting of empty segments and incorrect durations.

More details at: https://github.com/kaltura/nginx-vod-module/pull/1604