### PR TITLE
Stop pinning patch versions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 !sample
 !static
 !scripts/build_basic.sh
+!scripts/fetch_latest.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,30 +20,32 @@ jobs:
       fail-fast: false
       matrix:
         nginx-version:
-          - 1.28.2
-          - 1.29.6
+          - '1.29'
+          - '1.30'
         ffmpeg-version:
           - null
-          - 6.1.4
-          - 7.1.3
+          - '6.1'
+          - '7.1'
           - '8.1'
         build-mode:
           - --add-module
           - --add-dynamic-module
     steps:
       - run: sudo apt-get update -qq
-      - run: mkdir nginx ffmpeg
       - run: |
           sudo apt-get install -y \
-            curl \
+            wget \
             build-essential \
             libfdk-aac-dev \
             libssl-dev \
             libxml2-dev \
             nasm \
             pkg-config
+      - uses: actions/checkout@v6
+        with:
+          path: nginx-vod-module
       - if: matrix.ffmpeg-version != null
-        run: curl -sL https://ffmpeg.org/releases/ffmpeg-${{ matrix.ffmpeg-version }}.tar.gz | tar -xz --strip-components 1 -C ffmpeg
+        run: ./nginx-vod-module/scripts/fetch_latest.sh https://ffmpeg.org/releases ffmpeg-${{ matrix.ffmpeg-version }} ffmpeg
       - if: matrix.ffmpeg-version != null
         working-directory: ffmpeg
         run: |
@@ -59,10 +61,7 @@ jobs:
           make -j$(nproc)
           sudo make install
       - run: sudo ldconfig
-      - uses: actions/checkout@v6
-        with:
-          path: nginx-vod-module
-      - run: curl -sL https://nginx.org/download/nginx-${{ matrix.nginx-version }}.tar.gz | tar -xz --strip-components 1 -C nginx
+      - run: ./nginx-vod-module/scripts/fetch_latest.sh https://nginx.org/download nginx-${{ matrix.nginx-version }} nginx
       - working-directory: nginx
         run: |
           ../nginx-vod-module/scripts/build_basic.sh \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,86 +2,86 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.5.1](https://github.com/diogoazevedos/nginx-vod-module/compare/v1.5.0...v1.5.1) (2025-07-31)
+## [1.5.1](https://github.com/dio-az/nginx-vod-module/compare/v1.5.0...v1.5.1) (2025-07-31)
 
 ### Bug Fixes
 
-- Avoid unnecessary heap alloc in HLS ([#49](https://github.com/diogoazevedos/nginx-vod-module/pull/49))
+- Avoid unnecessary heap alloc in HLS ([#49](https://github.com/dio-az/nginx-vod-module/pull/49))
 
-## [1.5.0](https://github.com/diogoazevedos/nginx-vod-module/compare/v1.4.0...v1.5.0) (2025-07-17)
+## [1.5.0](https://github.com/dio-az/nginx-vod-module/compare/v1.4.0...v1.5.0) (2025-07-17)
 
 ### Features
 
-- Add HLS session key support ([#46](https://github.com/diogoazevedos/nginx-vod-module/pull/46))
+- Add HLS session key support ([#46](https://github.com/dio-az/nginx-vod-module/pull/46))
 
 ### Bug Fixes
 
-- Remove `libxml2` deprecation error ([#45](https://github.com/diogoazevedos/nginx-vod-module/pull/45))
+- Remove `libxml2` deprecation error ([#45](https://github.com/dio-az/nginx-vod-module/pull/45))
 
-## [1.4.0](https://github.com/diogoazevedos/nginx-vod-module/compare/v1.3.0...v1.4.0) (2025-07-08)
-
-### Features
-
-- Add multi-DRM support for HLS SAMPLE-AES-CTR ([#42](https://github.com/diogoazevedos/nginx-vod-module/pull/42))
-
-## [1.3.0](https://github.com/diogoazevedos/nginx-vod-module/compare/v1.2.0...v1.3.0) (2025-06-29)
+## [1.4.0](https://github.com/dio-az/nginx-vod-module/compare/v1.3.0...v1.4.0) (2025-07-08)
 
 ### Features
 
-- Improve encrypted DASH packager constants ([#41](https://github.com/diogoazevedos/nginx-vod-module/pull/41))
-- Extend video range SDR support ([#39](https://github.com/diogoazevedos/nginx-vod-module/pull/39))
-- Add video range HLG support ([#38](https://github.com/diogoazevedos/nginx-vod-module/pull/38))
-- Improve DASH packager constants ([#37](https://github.com/diogoazevedos/nginx-vod-module/pull/37))
+- Add multi-DRM support for HLS SAMPLE-AES-CTR ([#42](https://github.com/dio-az/nginx-vod-module/pull/42))
 
-## [1.2.0](https://github.com/diogoazevedos/nginx-vod-module/compare/v1.1.0...v1.2.0) (2025-06-10)
+## [1.3.0](https://github.com/dio-az/nginx-vod-module/compare/v1.2.0...v1.3.0) (2025-06-29)
 
 ### Features
 
-- Allow HLS version tuning ([#34](https://github.com/diogoazevedos/nginx-vod-module/pull/34))
-- Improve HLS builder memory usage and constants ([#33](https://github.com/diogoazevedos/nginx-vod-module/pull/33))
-- Set HLS version based on feature ([#32](https://github.com/diogoazevedos/nginx-vod-module/pull/32))
+- Improve encrypted DASH packager constants ([#41](https://github.com/dio-az/nginx-vod-module/pull/41))
+- Extend video range SDR support ([#39](https://github.com/dio-az/nginx-vod-module/pull/39))
+- Add video range HLG support ([#38](https://github.com/dio-az/nginx-vod-module/pull/38))
+- Improve DASH packager constants ([#37](https://github.com/dio-az/nginx-vod-module/pull/37))
+
+## [1.2.0](https://github.com/dio-az/nginx-vod-module/compare/v1.1.0...v1.2.0) (2025-06-10)
+
+### Features
+
+- Allow HLS version tuning ([#34](https://github.com/dio-az/nginx-vod-module/pull/34))
+- Improve HLS builder memory usage and constants ([#33](https://github.com/dio-az/nginx-vod-module/pull/33))
+- Set HLS version based on feature ([#32](https://github.com/dio-az/nginx-vod-module/pull/32))
 
 ### Bug Fixes
 
-- Fix regression in DRM-enabled HLS builder ([#36](https://github.com/diogoazevedos/nginx-vod-module/pull/36))
-- Fix HLS version merge ([#35](https://github.com/diogoazevedos/nginx-vod-module/pull/35))
+- Fix regression in DRM-enabled HLS builder ([#36](https://github.com/dio-az/nginx-vod-module/pull/36))
+- Fix HLS version merge ([#35](https://github.com/dio-az/nginx-vod-module/pull/35))
 
-## [1.1.0](https://github.com/diogoazevedos/nginx-vod-module/compare/v1.0.0...v1.1.0) (2025-05-16)
+## [1.1.0](https://github.com/dio-az/nginx-vod-module/compare/v1.0.0...v1.1.0) (2025-05-16)
 
 ### Features
 
-- Update minimum HLS version ([#26](https://github.com/diogoazevedos/nginx-vod-module/pull/26))
-- Add HLS independent segments tag ([#25](https://github.com/diogoazevedos/nginx-vod-module/pull/25))
+- Update minimum HLS version ([#26](https://github.com/dio-az/nginx-vod-module/pull/26))
+- Add HLS independent segments tag ([#25](https://github.com/dio-az/nginx-vod-module/pull/25))
 
 ### Bug Fixes
 
-- Ensure that DASH request version is correct ([#28](https://github.com/diogoazevedos/nginx-vod-module/pull/28))
+- Ensure that DASH request version is correct ([#28](https://github.com/dio-az/nginx-vod-module/pull/28))
 
-## [1.0.0](https://github.com/diogoazevedos/nginx-vod-module/compare/26f06877b0f2a2336e59cda93a3de18d7b23a3e2...v1.0.0) (2025-05-06)
+## [1.0.0](https://github.com/dio-az/nginx-vod-module/compare/26f06877b0f2a2336e59cda93a3de18d7b23a3e2...v1.0.0) (2025-05-06)
 
 ### ⚠ BREAKING CHANGES
 
-- Drop support for HDS and MSS ([#13](https://github.com/diogoazevedos/nginx-vod-module/pull/13))
-- Improve compliance with DASH specification ([#11](https://github.com/diogoazevedos/nginx-vod-module/pull/11))
-- Use last audio track assuming higher bitrate ([#9](https://github.com/diogoazevedos/nginx-vod-module/pull/9))
+- Drop support for HDS and MSS ([#13](https://github.com/dio-az/nginx-vod-module/pull/13))
+- Improve compliance with DASH specification ([#11](https://github.com/dio-az/nginx-vod-module/pull/11))
+- Use last audio track assuming higher bitrate ([#9](https://github.com/dio-az/nginx-vod-module/pull/9))
 
 ### Features
 
-- Add quick development setup ([#20](https://github.com/diogoazevedos/nginx-vod-module/pull/20))
-- Support sequence ID in the representation ID ([#17](https://github.com/diogoazevedos/nginx-vod-module/pull/17))
-- Add HLS characteristics support ([#6](https://github.com/diogoazevedos/nginx-vod-module/pull/6))
-- Add DASH role scheme support ([#5](https://github.com/diogoazevedos/nginx-vod-module/pull/5))
-- Update CI dependencies ([#4](https://github.com/diogoazevedos/nginx-vod-module/pull/4))
+- Add quick development setup ([#20](https://github.com/dio-az/nginx-vod-module/pull/20))
+- Support sequence ID in the representation ID ([#17](https://github.com/dio-az/nginx-vod-module/pull/17))
+- Add HLS characteristics support ([#6](https://github.com/dio-az/nginx-vod-module/pull/6))
+- Add DASH role scheme support ([#5](https://github.com/dio-az/nginx-vod-module/pull/5))
+- Update CI dependencies ([#4](https://github.com/dio-az/nginx-vod-module/pull/4))
 
 ### Bug Fixes
 
-- Fix DASH representation ID for single sequence ([#23](https://github.com/diogoazevedos/nginx-vod-module/pull/23))
-- Ensure that clock_gettime check works ([#22](https://github.com/diogoazevedos/nginx-vod-module/pull/22))
-- Ensure that lang and label are not empty ([#12](https://github.com/diogoazevedos/nginx-vod-module/pull/12))
-- Ensure that track grouping is correct ([#10](https://github.com/diogoazevedos/nginx-vod-module/pull/10))
-- Ensure that each audio group has a default ([#8](https://github.com/diogoazevedos/nginx-vod-module/pull/8))
-- Ensure that sequence autoselect is enabled by default ([#7](https://github.com/diogoazevedos/nginx-vod-module/pull/7))
-- Ensure that media info inherits the sequence tags ([#1](https://github.com/diogoazevedos/nginx-vod-module/pull/1))
+- Fix DASH representation ID for single sequence ([#23](https://github.com/dio-az/nginx-vod-module/pull/23))
+- Ensure that clock_gettime check works ([#22](https://github.com/dio-az/nginx-vod-module/pull/22))
+- Ensure that lang and label are not empty ([#12](https://github.com/dio-az/nginx-vod-module/pull/12))
+- Ensure that track grouping is correct ([#10](https://github.com/dio-az/nginx-vod-module/pull/10))
+- Ensure that each audio group has a default ([#8](https://github.com/dio-az/nginx-vod-module/pull/8))
+- Ensure that sequence autoselect is enabled by default ([#7](https://github.com/dio-az/nginx-vod-module/pull/7))
+- Ensure that media info inherits the sequence tags ([#1](https://github.com/dio-az/nginx-vod-module/pull/1))
 
 > For previous versions please check at
 [`kaltura/nginx-vod-module/CHANGELOG.md`](https://github.com/kaltura/nginx-vod-module/blob/26f06877b0f2a2336e59cda93a3de18d7b23a3e2/CHANGELOG.md).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3.23.3 AS build
+FROM alpine:3.23 AS build
 
 ARG FFMPEG_VERSION=8.1
-ARG NGINX_VERSION=1.29.6
+ARG NGINX_VERSION=1.30
 
 RUN apk --no-cache add \
 		build-base \
@@ -13,10 +13,12 @@ RUN apk --no-cache add \
 		libxml2-dev \
 		nasm \
 		fdk-aac-dev \
-		openssl-dev \
-	&& mkdir /ffmpeg /nginx \
-	&& wget -qO- https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz | tar -xz --strip-components 1 -C /ffmpeg \
-	&& wget -qO- https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -xz --strip-components 1 -C /nginx
+		openssl-dev
+
+COPY scripts/fetch_latest.sh /usr/local/bin/fetch_latest
+
+RUN fetch_latest https://ffmpeg.org/releases ffmpeg-${FFMPEG_VERSION} ffmpeg \
+	&& fetch_latest https://nginx.org/download nginx-${NGINX_VERSION} nginx
 
 WORKDIR /ffmpeg
 
@@ -76,7 +78,7 @@ RUN /nginx-vod-module/scripts/build_basic.sh \
 		--with-ld-opt='-L/opt/ffmpeg/lib -Wl,-rpath,/opt/ffmpeg/lib' \
 	&& make install
 
-FROM alpine:3.23.3
+FROM alpine:3.23
 
 LABEL maintainer="Diogo Azevedo <diogoazevedos@gmail.com>"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NGINX-based VOD Packager
-## nginx-vod-module [![CI](https://github.com/diogoazevedos/nginx-vod-module/actions/workflows/main.yml/badge.svg)](https://github.com/diogoazevedos/nginx-vod-module/actions/workflows/main.yml)
+## nginx-vod-module [![CI](https://github.com/dio-az/nginx-vod-module/actions/workflows/main.yml/badge.svg)](https://github.com/dio-az/nginx-vod-module/actions/workflows/main.yml)
 
 ### Features
 

--- a/scripts/fetch_latest.sh
+++ b/scripts/fetch_latest.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+filename=$(wget -qO- "$1" | grep -oE "$2(\.[0-9]+)?\.tar\.gz" | sort -V | tail -n1)
+
+mkdir -p "$3"
+wget -qO- "$1/$filename" | tar -xz --strip-components 1 -C "$3"


### PR DESCRIPTION
Pin **major** and **minor** only. **Patch** updates from dependencies are picked up automatically on rebuild, without manual intervention. Also updates GitHub links.