### PR TITLE
Skip headers without named field offsets

### DIFF
--- a/ngx_child_http_request.c
+++ b/ngx_child_http_request.c
@@ -400,6 +400,10 @@ ngx_child_request_copy_headers(
 #if defined(nginx_version) && nginx_version >= 1023000
 	// zero all named header fields
 	for (hh = ngx_http_headers_in; hh->name.len; hh++) {
+		if (hh->offset == 0) {
+			continue;
+		}
+
 		ph = (ngx_table_elt_t**)((char*)dest + hh->offset);
 		*ph = NULL;
 	}
@@ -451,7 +455,7 @@ ngx_child_request_copy_headers(
 
 		// update the header pointer, if exists
 		hh = ngx_hash_find(&cmcf->headers_in_hash, ch->hash, ch->lowcase_key, ch->key.len);
-		if (hh) {
+		if (hh && hh->offset != 0) {
 #if defined(nginx_version) && nginx_version >= 1023000
 			ph = (ngx_table_elt_t**)((char*)dest + hh->offset);
 


### PR DESCRIPTION
As reported in https://github.com/kaltura/nginx-vod-module/issues/1606 and fixed by https://github.com/kaltura/nginx-vod-module/pull/1608, NGINX v1.31 started registering known request headers with offset `0` when no matching `ngx_http_headers_in_t` field exists, corrupting the destination and its headers list when treated as a real offset.

Skip those zero-offset entries when clearing or updating copied named header pointers. 