### PR TITLE
Update mainline nginx to v1.31

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         nginx-version:
-          - '1.29'
           - '1.30'
+          - '1.31'
         ffmpeg-version:
           - null
           - '6.1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM alpine:3.23 AS build
 
 ARG FFMPEG_VERSION=8.1
-ARG NGINX_VERSION=1.30
+ARG NGINX_VERSION=1.31
 
 RUN apk --no-cache add \
 		build-base \
@@ -80,7 +80,7 @@ RUN /nginx-vod-module/scripts/build_basic.sh \
 
 FROM alpine:3.23
 
-LABEL maintainer="Diogo Azevedo <diogoazevedos@gmail.com>"
+LABEL maintainer="Diogo Azevedo <hi@dio-az.dev>"
 
 RUN apk --no-cache add \
 		zlib \

--- a/sample/debug.conf
+++ b/sample/debug.conf
@@ -69,8 +69,6 @@ http {
 		proxy_busy_buffers_size 128k;
 		proxy_max_temp_file_size 0;
 
-		proxy_http_version 1.1;
-
 		proxy_ssl_session_reuse on;
 
 		vod_mode mapped;
@@ -82,19 +80,16 @@ http {
 		location ^~ /mapping/ {
 			internal;
 			proxy_pass http://origin_service/mapping/;
-			include keepalive.conf;
 		}
 
 		location ^~ /drm/ {
 			internal;
 			proxy_pass http://origin_service/drm/;
-			include keepalive.conf;
 		}
 
 		location ^~ /storage/ {
 			internal;
 			proxy_pass http://origin_service/storage/;
-			include keepalive.conf;
 		}
 
 		vod_segment_duration 2000;

--- a/sample/keepalive.conf
+++ b/sample/keepalive.conf
@@ -1,1 +1,0 @@
-proxy_set_header Connection '';

--- a/sample/mapped.conf
+++ b/sample/mapped.conf
@@ -8,14 +8,12 @@ location ^~ /mapping/ {
 	internal;
 	proxy_pass http://origin_service/mapping/;
 	proxy_set_header Host host.docker.internal;
-	include keepalive.conf;
 }
 
 location ^~ /drm/ {
 	internal;
 	proxy_pass http://origin_service/drm/;
 	proxy_set_header Host host.docker.internal;
-	include keepalive.conf;
 }
 
 location ^~ /storage/ {
@@ -24,5 +22,4 @@ location ^~ /storage/ {
 	# proxy_set_header Host host.docker.internal;
 	proxy_pass http://media_sample_storage/;
 	proxy_set_header Host media-sample-storage.s3.eu-central-1.amazonaws.com;
-	include keepalive.conf;
 }

--- a/sample/nginx.conf
+++ b/sample/nginx.conf
@@ -96,8 +96,6 @@ http {
 		proxy_busy_buffers_size 128k;
 		proxy_max_temp_file_size 0;
 
-		proxy_http_version 1.1;
-
 		proxy_ssl_session_reuse on;
 
 		# include remote.conf;

--- a/sample/remote.conf
+++ b/sample/remote.conf
@@ -8,5 +8,4 @@ location ~ ^/storage/[^/]+/[^/]+/(?<path>.+) {
 	# proxy_set_header Host host.docker.internal;
 	proxy_pass http://media_sample_storage/$path;
 	proxy_set_header Host media-sample-storage.s3.eu-central-1.amazonaws.com;
-	include keepalive.conf;
 }


### PR DESCRIPTION
Bumps the mainline NGINX to `v1.31` and removes `proxy_http_version 1.1` and `proxy_set_header Connection ''` from the sample configs as these are now defaults since `v1.30`.