### PR TITLE
Detach pool-owned extradata before decoder teardown

### DIFF
--- a/vod/filters/audio_decoder.c
+++ b/vod/filters/audio_decoder.c
@@ -141,6 +141,12 @@ audio_decoder_init(
 
 void
 audio_decoder_free(audio_decoder_state_t* state) {
+	// NOTE: detach pool-owned extradata before teardown. avcodec_free_context() would otherwise
+	// call free() on request-pool memory.
+	if (state->decoder != NULL) {
+		state->decoder->extradata = NULL;
+		state->decoder->extradata_size = 0;
+	}
 	avcodec_free_context(&state->decoder);
 	av_frame_free(&state->decoded_frame);
 }

--- a/vod/thumb/thumb_grabber.c
+++ b/vod/thumb/thumb_grabber.c
@@ -101,6 +101,13 @@ thumb_grabber_free_state(void* context) {
 	}
 	av_frame_free(&state->decoded_frame);
 	avcodec_free_context(&state->encoder);
+
+	// NOTE: detach pool-owned extradata before teardown. avcodec_free_context() would otherwise
+	// call free() on request-pool memory.
+	if (state->decoder != NULL) {
+		state->decoder->extradata = NULL;
+		state->decoder->extradata_size = 0;
+	}
 	avcodec_free_context(&state->decoder);
 }
 


### PR DESCRIPTION
Fixes regression introduced in #71. The migration to `avcodec_free_context()` caused decoder teardown to free `extradata` pointing into the request pool, aborting the worker on thumb and audio-decoded requests.

Clear `extradata` before teardown so `av_freep()` becomes a no-op. Encoders are unaffected.

Fixes #108