### PR TITLE
Fix truncated cbcs fMP4 video segments

### DIFF
--- a/vod/mp4/mp4_cbcs_encrypt.c
+++ b/vod/mp4/mp4_cbcs_encrypt.c
@@ -301,6 +301,40 @@ mp4_cbcs_encrypt_video_init_track(mp4_cbcs_encrypt_video_stream_state_t* stream_
 }
 
 static vod_status_t
+mp4_cbcs_encrypt_video_finish_packet(mp4_cbcs_encrypt_video_stream_state_t* stream_state, bool_t* done) {
+	bool_t init_track = FALSE;
+	vod_status_t rc;
+
+	*done = FALSE;
+
+	// reset parser state for the next packet
+	stream_state->cur_state = STATE_PACKET_SIZE;
+	stream_state->length_bytes_left = stream_state->nal_packet_size_length;
+	stream_state->packet_size_left = 0;
+
+	if (stream_state->base.frame_size_left > 0) {
+		// more NAL units in this frame
+		return VOD_OK;
+	}
+
+	// move to the next frame
+	if (!mp4_cbcs_encrypt_move_to_next_frame(&stream_state->base, &init_track)) {
+		// no frames left, request a flush (gated by flush_left until all writers finish)
+		*done = TRUE;
+		return mp4_cbcs_encrypt_flush(stream_state->base.state);
+	}
+
+	if (init_track) {
+		rc = mp4_cbcs_encrypt_video_init_track(stream_state);
+		if (rc != VOD_OK) {
+			return rc;
+		}
+	}
+
+	return VOD_OK;
+}
+
+static vod_status_t
 mp4_cbcs_encrypt_video_write_buffer(void* context, u_char* buffer, uint32_t size) {
 	mp4_cbcs_encrypt_video_stream_state_t* stream_state =
 		(mp4_cbcs_encrypt_video_stream_state_t*)context;
@@ -314,7 +348,7 @@ mp4_cbcs_encrypt_video_write_buffer(void* context, u_char* buffer, uint32_t size
 	uint32_t size_left;
 	int32_t cur_shift;
 	uint8_t nal_type;
-	bool_t init_track;
+	bool_t finished;
 	bool_t is_slice;
 	vod_status_t rc;
 
@@ -476,7 +510,20 @@ mp4_cbcs_encrypt_video_write_buffer(void* context, u_char* buffer, uint32_t size
 				}
 
 				stream_state->packet_size_left -= slice_header_buf_size - 1;
-				stream_state->cur_state = STATE_PACKET_COPY;
+				if (stream_state->packet_size_left > 0) {
+					// remaining packet bytes are still in the input, copy them as clear
+					stream_state->cur_state = STATE_PACKET_COPY;
+					break;
+				}
+
+				// packet written, finish it (flushes once all frames are done)
+				rc = mp4_cbcs_encrypt_video_finish_packet(stream_state, &finished);
+				if (rc != VOD_OK) {
+					return rc;
+				}
+				if (finished) {
+					return VOD_OK;
+				}
 				break;
 			}
 
@@ -576,27 +623,13 @@ mp4_cbcs_encrypt_video_write_buffer(void* context, u_char* buffer, uint32_t size
 				break;
 			}
 
-			// finished a packet
-			stream_state->cur_state = STATE_PACKET_SIZE;
-			stream_state->length_bytes_left = stream_state->nal_packet_size_length;
-			stream_state->packet_size_left = 0;
-
-			if (stream_state->base.frame_size_left > 0) {
-				break;
+			// packet written, finish it (flushes once all frames are done)
+			rc = mp4_cbcs_encrypt_video_finish_packet(stream_state, &finished);
+			if (rc != VOD_OK) {
+				return rc;
 			}
-
-			// move to the next frame
-			init_track = FALSE;
-			if (!mp4_cbcs_encrypt_move_to_next_frame(&stream_state->base, &init_track)) {
-				// finished all frames
-				return mp4_cbcs_encrypt_flush(state);
-			}
-
-			if (init_track) {
-				rc = mp4_cbcs_encrypt_video_init_track(stream_state);
-				if (rc != VOD_OK) {
-					return rc;
-				}
+			if (finished) {
+				return VOD_OK;
 			}
 
 			break;


### PR DESCRIPTION
When the last NAL of a segment is a slice with less than one AES block to encrypt, the writer takes the "packet smaller than block" branch. That branch breaks out and waits for the loop to come back and finish the packet, but for the last NAL there is no more input, so it never does. The flush is skipped, the buffered media is dropped, and only the fragment header is sent, truncating the response.

Extracts the finish-and-flush step to `mp4_cbcs_encrypt_video_finish_packet` and calls it from both branches, so the buffer is always flushed once all frames are done.

Fixes #117