### PR TITLE
Update CI dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build:
     name: Build for NGINX ${{ matrix.nginx-version }} using ${{ matrix.build-mode }} ${{ matrix.ffmpeg-version && format('and FFmpeg {0}', matrix.ffmpeg-version) || '' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
             libfdk-aac-dev \
             libssl-dev \
             libxml2-dev \
+            libpcre2-dev \
             nasm \
             pkg-config
       - uses: actions/checkout@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
             libxml2-dev \
             nasm \
             pkg-config
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           path: nginx-vod-module
       - if: matrix.ffmpeg-version != null

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3.23 AS build
+FROM alpine:3.24 AS build
 
 ARG FFMPEG_VERSION=8.1
 ARG NGINX_VERSION=1.31
@@ -78,7 +78,7 @@ RUN /nginx-vod-module/scripts/build_basic.sh \
 		--with-ld-opt='-L/opt/ffmpeg/lib -Wl,-rpath,/opt/ffmpeg/lib' \
 	&& make install
 
-FROM alpine:3.23
+FROM alpine:3.24
 
 LABEL maintainer="Diogo Azevedo <hi@dio-az.dev>"
 


### PR DESCRIPTION
Routine dependency refresh; updates:

- Docker `alpine` image to `3.24`
- CI runner to `ubuntu-26.04`
- GitHub `actions/checkout` to `v7`

Additionally, adds `libpcre2-dev` to make PCRE an explicit build dependency.