### PR TITLE
Drop support for NGINX below v1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@
 
 #### Dependencies
 
+> [!IMPORTANT]
+> Building this module requires **NGINX v1.23+**. Older releases are rejected at build time. Prefer
+> a currently-supported release - NGINX only maintains its current mainline and stable branches.
+
 In general, if the required dependencies for building NGINX are present, it should be possible to
 build `nginx-vod-module`. However, some optional features of the module require additional
-dependencies. These are detected during the `configure` step — if any dependency is missing, the
+dependencies. These are detected during the `configure` step - if any dependency is missing, the
 corresponding feature will be disabled.
 
 The optional features are:

--- a/ngx_child_http_request.c
+++ b/ngx_child_http_request.c
@@ -25,9 +25,7 @@ typedef struct {
 
 	// deferred init
 	ngx_buf_t* response_buffer;
-#if defined(nginx_version) && nginx_version >= 1013010
 	ngx_chain_t* response_chain;
-#endif
 	ngx_list_t upstream_headers;
 
 	// temporary completion state
@@ -121,7 +119,6 @@ ngx_child_request_wev_handler(ngx_http_request_t* r) {
 
 	u = sr->upstream;
 
-#if defined(nginx_version) && nginx_version >= 1013010
 	if (is_in_memory(ctx)) {
 		if (sr->out == NULL || sr->out->buf == NULL) {
 			ngx_log_error(
@@ -134,27 +131,13 @@ ngx_child_request_wev_handler(ngx_http_request_t* r) {
 	} else {
 		b = NULL;
 	}
-#else
-	if (u == NULL) {
-		ngx_log_error(
-			NGX_LOG_ERR, r->connection->log, 0, "ngx_child_request_wev_handler: unexpected, upstream is null"
-		);
-		return;
-	}
-
-	b = &u->buffer;
-#endif
 
 	// code taken from echo-nginx-module to work around nginx subrequest issues
 	if (r == r->connection->data && r->postponed) {
 		if (r->postponed->request) {
 			r->connection->data = r->postponed->request;
 
-#if defined(nginx_version) && nginx_version >= 8012
 			ngx_http_post_request(r->postponed->request, NULL);
-#else
-			ngx_http_post_request(r->postponed->request);
-#endif
 		} else {
 			ngx_http_output_filter(r, NULL);
 		}
@@ -320,11 +303,7 @@ ngx_child_request_finished_handler(ngx_http_request_t* r, void* data, ngx_int_t 
 	if (r != r->connection->data
 	    && r->postponed
 	    && (r->main->posted_requests == NULL || r->main->posted_requests->request != pr)) {
-#if defined(nginx_version) && nginx_version >= 8012
 		ngx_http_post_request(pr, NULL);
-#else
-		ngx_http_post_request(pr);
-#endif
 	}
 
 	return NGX_OK;
@@ -373,33 +352,12 @@ ngx_child_request_initial_wev_handler(ngx_http_request_t* r) {
 		return;
 	}
 
-#if defined(nginx_version) && nginx_version >= 1013010
 	r->out = ctx->response_chain;
-#else
-	u->buffer = *ctx->response_buffer;
-#endif
 
 	// initialize the headers list
 	u->headers_in.headers = ctx->upstream_headers;
 	u->headers_in.headers.last = &u->headers_in.headers.part;
 }
-
-#if !defined(nginx_version) || nginx_version < 1023000
-static void
-ngx_child_request_update_multi_header(ngx_array_t* arr, ngx_table_elt_t* cur_value, ngx_table_elt_t* new_value) {
-	ngx_table_elt_t** cur = arr->elts;
-	ngx_table_elt_t** last = cur + arr->nelts;
-
-	for (; cur < last; cur++) {
-		if (*cur != cur_value) {
-			continue;
-		}
-
-		*cur = new_value;
-		break;
-	}
-}
-#endif
 
 static ngx_int_t
 ngx_child_request_copy_headers(
@@ -435,7 +393,6 @@ ngx_child_request_copy_headers(
 		return NGX_ERROR;
 	}
 
-#if defined(nginx_version) && nginx_version >= 1023000
 	// zero all named header fields
 	for (hh = ngx_http_headers_in; hh->name.len; hh++) {
 		if (hh->offset == 0) {
@@ -445,7 +402,6 @@ ngx_child_request_copy_headers(
 		ph = (ngx_table_elt_t**)((char*)dest + hh->offset);
 		*ph = NULL;
 	}
-#endif
 
 	output = dest->headers.last->elts;
 
@@ -494,26 +450,10 @@ ngx_child_request_copy_headers(
 		// update the header pointer, if exists
 		hh = ngx_hash_find(&cmcf->headers_in_hash, ch->hash, ch->lowcase_key, ch->key.len);
 		if (hh && hh->offset != 0) {
-#if defined(nginx_version) && nginx_version >= 1023000
 			ph = (ngx_table_elt_t**)((char*)dest + hh->offset);
 
 			output->next = *ph;
 			*ph = output;
-#else
-			if ((ch->key.len == sizeof("cookie") - 1
-			     && ngx_memcmp(ch->lowcase_key, "cookie", sizeof("cookie") - 1) == 0)
-			    || (ch->key.len == sizeof("x-forwarded-for") - 1
-			        && ngx_memcmp(ch->lowcase_key, "x-forwarded-for", sizeof("x-forwarded-for") - 1)
-			               == 0)) {
-				// multi header
-				ngx_child_request_update_multi_header((ngx_array_t*)((char*)dest + hh->offset), ch, output);
-			} else {
-				// single header
-				ph = (ngx_table_elt_t**)((char*)dest + hh->offset);
-
-				*ph = output;
-			}
-#endif
 		}
 
 		output++;
@@ -529,9 +469,7 @@ ngx_child_request_copy_headers(
 		if (dest->range == NULL) {
 			h = output++;
 			h->hash = range_hash;
-#if defined(nginx_version) && nginx_version >= 1023000
 			h->next = NULL;
-#endif
 			h->key = range_key;
 			h->lowcase_key = range_lowcase_key;
 			dest->range = h;
@@ -589,7 +527,6 @@ ngx_child_request_start(
 	child_ctx->callback_context = callback_context;
 	child_ctx->response_buffer = response_buffer;
 
-#if defined(nginx_version) && nginx_version >= 1013010
 	if (response_buffer != NULL) {
 		child_ctx->response_chain = ngx_alloc_chain_link(r->pool);
 		if (child_ctx->response_chain == NULL) {
@@ -601,7 +538,6 @@ ngx_child_request_start(
 
 		child_ctx->response_chain->buf = response_buffer;
 	}
-#endif
 
 	// build the subrequest uri
 	uri.data = ngx_pnalloc(r->pool, internal_location->len + params->base_uri.len + 1);

--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -5203,9 +5203,7 @@ ngx_http_vod_handle_thumb_redirect(ngx_http_vod_ctx_t* ctx, media_set_t* media_s
 	}
 
 	location->hash = 1;
-#if (nginx_version >= 1023000)
 	location->next = NULL;
-#endif
 	ngx_str_set(&location->key, "Location");
 	location->value = url;
 

--- a/ngx_http_vod_module.h
+++ b/ngx_http_vod_module.h
@@ -5,6 +5,10 @@
 #include <ngx_http.h>
 #include <ngx_vod_version.h>
 
+#if nginx_version < 1023000
+#error "ngx_http_vod_module requires nginx >= 1.23.0"
+#endif
+
 // globals
 extern ngx_module_t ngx_http_vod_module;
 

--- a/ngx_http_vod_utils.c
+++ b/ngx_http_vod_utils.c
@@ -408,7 +408,6 @@ found:
 	return NGX_OK;
 }
 
-#if (nginx_version >= 1023000)
 static ngx_table_elt_t*
 ngx_http_vod_push_cache_control(ngx_http_request_t* r) {
 	ngx_table_elt_t* cc;
@@ -437,44 +436,6 @@ ngx_http_vod_push_cache_control(ngx_http_request_t* r) {
 
 	return cc;
 }
-#else
-static ngx_table_elt_t*
-ngx_http_vod_push_cache_control(ngx_http_request_t* r) {
-	ngx_uint_t i;
-	ngx_table_elt_t *cc, **ccp;
-
-	ccp = r->headers_out.cache_control.elts;
-
-	if (ccp == NULL) {
-		if (ngx_array_init(&r->headers_out.cache_control, r->pool, 1, sizeof(ngx_table_elt_t*))
-		    != NGX_OK) {
-			return NULL;
-		}
-
-		ccp = ngx_array_push(&r->headers_out.cache_control);
-		if (ccp == NULL) {
-			return NULL;
-		}
-
-		cc = ngx_list_push(&r->headers_out.headers);
-		if (cc == NULL) {
-			return NULL;
-		}
-
-		cc->hash = 1;
-		ngx_str_set(&cc->key, "Cache-Control");
-		*ccp = cc;
-	} else {
-		for (i = 1; i < r->headers_out.cache_control.nelts; i++) {
-			ccp[i]->hash = 0;
-		}
-
-		cc = ccp[0];
-	}
-
-	return cc;
-}
-#endif
 
 // A run down version of ngx_http_set_expires
 ngx_int_t
@@ -492,9 +453,7 @@ ngx_http_vod_set_expires(ngx_http_request_t* r, time_t expires_time) {
 		}
 
 		r->headers_out.expires = e;
-#if (nginx_version >= 1023000)
 		e->next = NULL;
-#endif
 
 		e->hash = 1;
 		ngx_str_set(&e->key, "Expires");


### PR DESCRIPTION
Removes the compatibility shims for older NGINX releases, keeping only the code path used by modern NGINX. This drops the legacy header-list layout, the old `ngx_http_post_request` signature, and the pre-`response_chain` upstream buffer handling.

> [!IMPORTANT]
> Minimum supported NGINX version is now **1.23.0**. Building against an older release will fail to compile, since the fallback code paths have been removed entirely.

> [!NOTE]
> NGINX 1.23.0 is from mid-2022 and no longer receives security patches under NGINX's maintenance policy. Since this is security-driven rather than an API break, I'm considering merging it into `v1.x` instead of holding it for the next major version.