### PR TITLE
Fix module version reporting

### DIFF
--- a/config
+++ b/config
@@ -4,13 +4,6 @@ ngx_module_libs=
 VOD_SRCS=
 VOD_DEPS=
 
-# version
-#
-VOD_DEFAULT_VERSION=1.11
-VOD_VERSION=${VOD_VERSION:-`git --git-dir=$ngx_addon_dir/.git describe 2>/dev/null`}
-VOD_VERSION=${VOD_VERSION:-$VOD_DEFAULT_VERSION}
-echo "#define NGINX_VOD_VERSION \""$VOD_VERSION"\"" > $NGX_OBJS/ngx_vod_version.h
-
 # taken from echo-nginx-module
 # nginx won't have HTTP_POSTPONE_FILTER_MODULE & HTTP_POSTPONE_FILTER_SRCS
 # defined since 1.9.11

--- a/ngx_http_vod_module.h
+++ b/ngx_http_vod_module.h
@@ -3,7 +3,9 @@
 
 // includes
 #include <ngx_http.h>
-#include <ngx_vod_version.h>
+
+// version
+#define NGINX_VOD_VERSION  "1.5.1"
 
 // globals
 extern ngx_module_t ngx_http_vod_module;


### PR DESCRIPTION
The module version was generated at build time via `git describe`, falling back to a hardcoded `1.11` when git metadata is unavailable, such as in tarball builds.

`NGINX_VOD_VERSION` is now defined directly in `ngx_http_vod_module.h`, removing the build-time generation so the reported version is always correct.

> [!NOTE]
> The version is now maintained manually and bumped per branch at release time, which is why it reads `1.5.1` on `main`.
