### PR TITLE
Make fMP4 the default HLS container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1803,11 +1803,11 @@ compatibility.
 #### vod_hls_container_format
 
 - **syntax**: `vod_hls_container_format mpegts | fmp4 | auto`
-- **default**: `auto`
+- **default**: `fmp4`
 - **context**: `http`, `server`, `location`
 
-Sets the container format of the HLS segments. The default behavior is to use `fmp4` for HEVC, and
-`mpegts` otherwise.
+Sets the container format of the HLS segments. When `auto`, `fmp4` is used for non-AVC video or
+`sample-aes-ctr` encryption, and `mpegts` otherwise.
 
 > [!NOTE]
 > Apple does not support HEVC over MPEG-TS.

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -1026,7 +1026,7 @@ ngx_http_vod_hls_merge_loc_conf(
 		conf->encryption_key_uri = prev->encryption_key_uri;
 	}
 	ngx_conf_merge_uint_value(
-		conf->m3u8_config.container_format, prev->m3u8_config.container_format, HLS_CONTAINER_AUTO
+		conf->m3u8_config.container_format, prev->m3u8_config.container_format, HLS_CONTAINER_FMP4
 	);
 	ngx_conf_merge_uint_value(conf->m3u8_config.m3u8_version, prev->m3u8_config.m3u8_version, 6);
 

--- a/sample/debug.conf
+++ b/sample/debug.conf
@@ -100,7 +100,6 @@ http {
 		vod_drm_single_key on;
 		vod_drm_clear_lead_segment_count 0;
 
-		vod_hls_container_format auto;
 		vod_hls_absolute_index_urls off;
 		vod_hls_absolute_master_urls off;
 		vod_hls_master_file_name_prefix '';
@@ -133,7 +132,6 @@ http {
 		location ~ ^/cenc/(?<playback_token>[^/]+)/ {
 			vod hls;
 			vod_drm_enabled on;
-			vod_hls_version 6;
 			vod_hls_encryption_method sample-aes-ctr;
 			add_header Cache-Control $cache_control_directives always;
 			include cors.conf;
@@ -142,7 +140,6 @@ http {
 		location ~ ^/cbcs/(?<playback_token>[^/]+)/ {
 			vod hls;
 			vod_drm_enabled on;
-			vod_hls_version 5;
 			vod_hls_encryption_key_uri 'skd://$vod_set_id';
 			vod_hls_encryption_key_format 'com.apple.streamingkeydelivery';
 			vod_hls_encryption_key_format_versions '1';

--- a/sample/nginx.conf
+++ b/sample/nginx.conf
@@ -109,7 +109,6 @@ http {
 		vod_drm_single_key on;
 		vod_drm_clear_lead_segment_count 0;
 
-		vod_hls_container_format auto;
 		vod_hls_absolute_index_urls off;
 		vod_hls_absolute_master_urls off;
 		vod_hls_master_file_name_prefix '';
@@ -142,7 +141,6 @@ http {
 		location ~ ^/cenc/(?<playback_token>[^/]+)/ {
 			vod hls;
 			vod_drm_enabled on;
-			vod_hls_version 6;
 			vod_hls_encryption_method sample-aes-ctr;
 			add_header Cache-Control $cache_control_directives always;
 			include cors.conf;
@@ -151,7 +149,6 @@ http {
 		location ~ ^/cbcs/(?<playback_token>[^/]+)/ {
 			vod hls;
 			vod_drm_enabled on;
-			vod_hls_version 5;
 			vod_hls_encryption_key_uri 'skd://$vod_set_id';
 			vod_hls_encryption_key_format 'com.apple.streamingkeydelivery';
 			vod_hls_encryption_key_format_versions '1';


### PR DESCRIPTION
`vod_hls_container_format` now defaults to `fmp4` instead of `auto`, so fMP4 is used for all codecs. `auto` is unchanged and still available.

> [!IMPORTANT]
> This change requires a minimum HLS version of `6`. Make sure to check your `vod_hls_version` setting.