### PR TITLE
Improve pipeline efficiency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,5 @@
 !sample
 !static
 !scripts/build_basic.sh
+!scripts/build_ffmpeg.sh
 !scripts/fetch_latest.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           path: nginx-vod-module
       - if: matrix.ffmpeg-version != null
-        run: ./nginx-vod-module/scripts/fetch_latest.sh https://ffmpeg.org/releases ffmpeg-${{ matrix.ffmpeg-version }} ffmpeg
+        run: ./nginx-vod-module/scripts/fetch_latest.sh ffmpeg.org/releases ffmpeg-${{ matrix.ffmpeg-version }}
       - if: matrix.ffmpeg-version != null
         working-directory: ffmpeg
         run: |
@@ -62,7 +62,7 @@ jobs:
           make -j$(nproc)
           sudo make install
       - run: sudo ldconfig
-      - run: ./nginx-vod-module/scripts/fetch_latest.sh https://nginx.org/download nginx-${{ matrix.nginx-version }} nginx
+      - run: ./nginx-vod-module/scripts/fetch_latest.sh nginx.org/download nginx-${{ matrix.nginx-version }}
       - working-directory: nginx
         run: |
           ../nginx-vod-module/scripts/build_basic.sh \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,11 +48,20 @@ jobs:
       - if: matrix.ffmpeg-version != null
         run: ./nginx-vod-module/scripts/fetch_latest.sh ffmpeg.org/releases ffmpeg-${{ matrix.ffmpeg-version }}
       - if: matrix.ffmpeg-version != null
+        id: ffmpeg-cache
+        uses: actions/cache@v6
+        with:
+          path: ffmpeg-cache
+          key: ${{ hashFiles('ffmpeg/**', 'nginx-vod-module/scripts/build_ffmpeg.sh') }}
+      - if: matrix.ffmpeg-version != null && steps.ffmpeg-cache.outputs.cache-hit != 'true'
         working-directory: ffmpeg
         run: |
           ../nginx-vod-module/scripts/build_ffmpeg.sh --prefix=/usr/local
-          sudo make install
-      - run: sudo ldconfig
+          make install DESTDIR=$GITHUB_WORKSPACE/ffmpeg-cache
+      - if: matrix.ffmpeg-version != null
+        run: |
+          sudo cp -aT ffmpeg-cache /
+          sudo ldconfig
       - run: ./nginx-vod-module/scripts/fetch_latest.sh nginx.org/download nginx-${{ matrix.nginx-version }}
       - working-directory: nginx
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,16 +50,7 @@ jobs:
       - if: matrix.ffmpeg-version != null
         working-directory: ffmpeg
         run: |
-          ./configure \
-            --prefix=/usr/local \
-            --disable-programs \
-            --disable-doc \
-            --disable-static \
-            --enable-gpl \
-            --enable-nonfree \
-            --enable-shared \
-            --enable-libfdk-aac
-          make -j$(nproc)
+          ../nginx-vod-module/scripts/build_ffmpeg.sh --prefix=/usr/local
           sudo make install
       - run: sudo ldconfig
       - run: ./nginx-vod-module/scripts/fetch_latest.sh nginx.org/download nginx-${{ matrix.nginx-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apk --no-cache add \
 
 COPY scripts/fetch_latest.sh /usr/local/bin/fetch_latest
 
-RUN fetch_latest https://ffmpeg.org/releases ffmpeg-${FFMPEG_VERSION} ffmpeg \
-	&& fetch_latest https://nginx.org/download nginx-${NGINX_VERSION} nginx
+RUN fetch_latest ffmpeg.org/releases ffmpeg-${FFMPEG_VERSION} \
+	&& fetch_latest nginx.org/download nginx-${NGINX_VERSION}
 
 WORKDIR /ffmpeg
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,35 +15,14 @@ RUN apk --no-cache add \
 		fdk-aac-dev \
 		openssl-dev
 
-COPY scripts/fetch_latest.sh /usr/local/bin/fetch_latest
+COPY scripts/fetch_latest.sh scripts/build_ffmpeg.sh /usr/local/bin/
 
-RUN fetch_latest ffmpeg.org/releases ffmpeg-${FFMPEG_VERSION} \
-	&& fetch_latest nginx.org/download nginx-${NGINX_VERSION}
+RUN fetch_latest.sh ffmpeg.org/releases ffmpeg-${FFMPEG_VERSION} \
+	&& fetch_latest.sh nginx.org/download nginx-${NGINX_VERSION}
 
 WORKDIR /ffmpeg
 
-RUN ./configure \
-		--prefix=/opt/ffmpeg \
-		--disable-programs \
-		--disable-doc \
-		--disable-static \
-		--disable-avdevice \
-		--disable-avformat \
-		--enable-shared \
-		--enable-gpl \
-		--enable-nonfree \
-		--enable-libfdk-aac \
-		--disable-everything \
-		--enable-filters \
-		--enable-decoder=h264 \
-		--enable-decoder=hevc \
-		--enable-decoder=vp8 \
-		--enable-decoder=vp9 \
-		--enable-decoder=av1 \
-		--enable-decoder=aac --enable-encoder=libfdk_aac \
-		--enable-encoder=mjpeg \
-	&& make -j$(nproc) \
-	&& make install
+RUN build_ffmpeg.sh --prefix=/opt/ffmpeg && make install
 
 COPY --exclude=sample --exclude=static . /nginx-vod-module
 

--- a/scripts/build_ffmpeg.sh
+++ b/scripts/build_ffmpeg.sh
@@ -14,6 +14,9 @@
 	--enable-filter=volume,amix,atempo \
 	--enable-decoder=h264,hevc,vp8,vp9,av1,aac \
 	--enable-encoder=libfdk_aac,mjpeg \
+	--enable-bsf=extract_extradata \
 	"$@"
+
+# `extract_extradata` pulls in av1_parse, missing for AV1 decoder before FFmpeg v7
 
 make -j$(nproc)

--- a/scripts/build_ffmpeg.sh
+++ b/scripts/build_ffmpeg.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+./configure \
+	--disable-programs \
+	--disable-doc \
+	--disable-static \
+	--disable-avdevice \
+	--disable-avformat \
+	--enable-shared \
+	--enable-gpl \
+	--enable-nonfree \
+	--enable-libfdk-aac \
+	--disable-everything \
+	--enable-filter=volume,amix,atempo \
+	--enable-decoder=h264,hevc,vp8,vp9,av1,aac \
+	--enable-encoder=libfdk_aac,mjpeg \
+	"$@"
+
+make -j$(nproc)

--- a/scripts/fetch_latest.sh
+++ b/scripts/fetch_latest.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-filename=$(wget -qO- "$1" | grep -oE "$2(\.[0-9]+)?\.tar\.gz" | sort -V | tail -n1)
+filename=$(wget -qO- "https://$1" | grep -oE "$2(\.[0-9]+)?\.tar\.gz" | sort -V | tail -n1)
+destination="${filename%%-*}"
 
-mkdir -p "$3"
-wget -qO- "$1/$filename" | tar -xz --strip-components 1 -C "$3"
+mkdir -p "$destination"
+wget -qO- "https://$1/$filename" | tar -xz --strip-components 1 -C "$destination"


### PR DESCRIPTION
Every pipeline run recompiles FFmpeg from source, even when an earlier run already built the same version, costing several minutes per job.

This change caches the FFmpeg build: the pipeline restores an existing build instead of recompiling FFmpeg, and only compiles a fresh one when FFmpeg releases a new patch.
