### PR TITLE
Ensure `fetch_latest` returns the correct version

### DIFF
--- a/scripts/fetch_latest.sh
+++ b/scripts/fetch_latest.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-filename=$(wget -qO- "https://$1" | grep -oE "$2(\.[0-9]+)?\.tar\.gz" | sort -V | tail -n1)
-destination="${filename%%-*}"
+package="${2%%-*}"
+version=$(wget -qO- "https://$1" | grep -oE "$2(\.[0-9]+)*\.tar\.gz" | sed -E "s/^$package-(.*)\.tar\.gz$/\1/" | sort -V | tail -n1)
 
-mkdir -p "$destination"
-wget -qO- "https://$1/$filename" | tar -xz --strip-components 1 -C "$destination"
+mkdir -p "$package"
+wget -qO- "https://$1/$package-$version.tar.gz" | tar -xz --strip-components 1 -C "$package"


### PR DESCRIPTION
Filenames were compared as whole strings, so a shorter version like `8.1` was outranking a newer patch release like `8.1.2`.
